### PR TITLE
Suggest changing light tile to report lux instead of %

### DIFF
--- a/devicetypes/bspranger/xiaomi-aqara-motion-sensor.src/xiaomi-aqara-motion-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-motion-sensor.src/xiaomi-aqara-motion-sensor.groovy
@@ -74,7 +74,7 @@ metadata {
             ]
         }
         valueTile("light", "device.Light", decoration: "flat", inactiveLabel: false, width: 2, height: 2) {
-            state "light", label:'${currentValue} \nlux', unit: ""
+            state "light", label:'Light\n${currentValue}\nlux', unit: ""
         }
         standardTile("reset", "device.reset", inactiveLabel: false, decoration: "flat", width: 2, height: 2) {
             state "default", action:"reset", label: "Reset Motion", icon:"st.motion.motion.active"


### PR DESCRIPTION
Hello 

I'd like to suggest changing units for light from % to lux for the Xiaomi Aqara motion sensor - which is what the sensor reports -

From Zigbee Cluster library spec
 
Identifier      Name
0x0400        Illuminance Measurement
MeasuredValue represents the Illuminance in Lux (symbol lx) as follows:
MeasuredValue = 10,000 x log10 Illuminance + 1

Here's some basic guide to lux if you haven't seen it before - I found it confusing at the beginning - but it's useful once you get a feel for it. 
From
https://www.engineeringtoolbox.com/light-level-rooms-d_708.html

Indoor Light Levels
The outdoor light level is approximately 10000 lux on a clear day. In a building in the area closest to the windows the light level may be reduced to approximately 1000 lux. In the middle area it may be as low as 25 - 50 lux. Additional lighting is often necessary to compensate low levels.

Earlier it was common with light levels in the range 100 - 300 lux for normal activities. Today the light level is more common in the range 500 - 1000 lux - depending on activity. For precision and detailed works the light level may even approach 1500 - 2000 lux."

I thought about changing the tile name to 'Illuminance'  also - but I kind of like the simplicity of 'Light'   - and 'Illuminance' is way long 

Let me know what you think.

Thanks!
Alec 

PS haven't done many pull requests - so hope I got it right.  In the end just changing the one line