### PR TITLE
Add 24 hour clock setting

### DIFF
--- a/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
@@ -45,6 +45,7 @@ preferences {
 	input name:"ReleaseTime", type:"number", title:"Minimum time in seconds for a press to clear", defaultValue: 2, displayDuringSetup: false
         input name:"PressType", type:"enum", options:["Toggle", "Momentary"], description:"Effects how the button toggles", defaultValue:"Toggle", displayDuringSetup: true
 	input name: "dateformat", type: "enum", title: "Set Date Format\n US (MDY) - UK (DMY) - Other (YMD)", description: "Date Format", required: false, options:["US","UK","Other"]
+	input name: "clockformat", type: "bool", title: "Use 24 hour clock?", defaultValue: false, required: false
 	input description: "Only change the settings below if you know what you're doing", displayDuringSetup: false, type: "paragraph", element: "paragraph", title: "ADVANCED SETTINGS"
 	input name: "voltsmax", title: "Max Volts\nA battery is at 100% at __ volts\nRange 2.8 to 3.4", type: "decimal", range: "2.8..3.4", defaultValue: 3, required: false
 	input name: "voltsmin", title: "Min Volts\nA battery is at 0% (needs replacing) at __ volts\nRange 2.0 to 2.7", type: "decimal", range: "2..2.7", defaultValue: 2.5, required: false
@@ -333,6 +334,7 @@ private checkIntervalEvent(text) {
 
 def formatDate(batteryReset) {
     def correctedTimezone = ""
+    def timeString = clockformat ? "HH:mm:ss" : "h:mm:ss aa"
 
     if (!(location.timeZone)) {
         correctedTimezone = TimeZone.getTimeZone("GMT")
@@ -346,18 +348,18 @@ def formatDate(batteryReset) {
         if (batteryReset)
             return new Date().format("MMM dd yyyy", correctedTimezone)
         else
-            return new Date().format("EEE MMM dd yyyy h:mm:ss a", correctedTimezone)
+            return new Date().format("EEE MMM dd yyyy ${timeString}", correctedTimezone)
     }
     else if (dateformat == "UK") {
         if (batteryReset)
             return new Date().format("dd MMM yyyy", correctedTimezone)
         else
-            return new Date().format("EEE dd MMM yyyy h:mm:ss a", correctedTimezone)
+            return new Date().format("EEE dd MMM yyyy ${timeString}", correctedTimezone)
         }
     else {
         if (batteryReset)
             return new Date().format("yyyy MMM dd", correctedTimezone)
         else
-            return new Date().format("EEE yyyy MMM dd h:mm:ss a", correctedTimezone)
+            return new Date().format("EEE yyyy MMM dd ${timeString}", correctedTimezone)
     }
 }

--- a/devicetypes/bspranger/xiaomi-aqara-door-window-sensor.src/xiaomi-aqara-door-window-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-door-window-sensor.src/xiaomi-aqara-door-window-sensor.groovy
@@ -35,6 +35,7 @@
  */
 preferences {
 	input name: "dateformat", type: "enum", title: "Set Date Format\n US (MDY) - UK (DMY) - Other (YMD)", description: "Date Format", required: false, options:["US","UK","Other"]
+	input name: "clockformat", type: "bool", title: "Use 24 hour clock?", defaultValue: false, required: false
 	input description: "Only change the settings below if you know what you're doing", displayDuringSetup: false, type: "paragraph", element: "paragraph", title: "ADVANCED SETTINGS"
 	input name: "voltsmax", title: "Max Volts\nA battery is at 100% at __ volts\nRange 2.8 to 3.4", type: "decimal", range: "2.8..3.4", defaultValue: 3, required: false
 	input name: "voltsmin", title: "Min Volts\nA battery is at 0% (needs replacing) at __ volts\nRange 2.0 to 2.7", type: "decimal", range: "2..2.7", defaultValue: 2.5, required: false
@@ -271,6 +272,7 @@ private checkIntervalEvent(text) {
 
 def formatDate(batteryReset) {
     def correctedTimezone = ""
+    def timeString = clockformat ? "HH:mm:ss" : "h:mm:ss aa"
 
     if (!(location.timeZone)) {
         correctedTimezone = TimeZone.getTimeZone("GMT")
@@ -284,18 +286,18 @@ def formatDate(batteryReset) {
         if (batteryReset)
             return new Date().format("MMM dd yyyy", correctedTimezone)
         else
-            return new Date().format("EEE MMM dd yyyy h:mm:ss a", correctedTimezone)
+            return new Date().format("EEE MMM dd yyyy ${timeString}", correctedTimezone)
     }
     else if (dateformat == "UK") {
         if (batteryReset)
             return new Date().format("dd MMM yyyy", correctedTimezone)
         else
-            return new Date().format("EEE dd MMM yyyy h:mm:ss a", correctedTimezone)
+            return new Date().format("EEE dd MMM yyyy ${timeString}", correctedTimezone)
         }
     else {
         if (batteryReset)
             return new Date().format("yyyy MMM dd", correctedTimezone)
         else
-            return new Date().format("EEE yyyy MMM dd h:mm:ss a", correctedTimezone)
+            return new Date().format("EEE yyyy MMM dd ${timeString}", correctedTimezone)
     }
 }

--- a/devicetypes/bspranger/xiaomi-aqara-leak-sensor.src/xiaomi-aqara-leak-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-leak-sensor.src/xiaomi-aqara-leak-sensor.groovy
@@ -36,6 +36,7 @@
 
 preferences {
 	input name: "dateformat", type: "enum", title: "Set Date Format\n US (MDY) - UK (DMY) - Other (YMD)", description: "Date Format", required: false, options:["US","UK","Other"]
+	input name: "clockformat", type: "bool", title: "Use 24 hour clock?", defaultValue: false, required: false
 	input description: "Only change the settings below if you know what you're doing", displayDuringSetup: false, type: "paragraph", element: "paragraph", title: "ADVANCED SETTINGS"
 	input name: "voltsmax", title: "Max Volts\nA battery is at 100% at __ volts\nRange 2.8 to 3.4", type: "decimal", range: "2.8..3.4", defaultValue: 3, required: false
 	input name: "voltsmin", title: "Min Volts\nA battery is at 0% (needs replacing) at __ volts\nRange 2.0 to 2.7", type: "decimal", range: "2..2.7", defaultValue: 2.5, required: false
@@ -283,6 +284,7 @@ private checkIntervalEvent(text) {
 
 def formatDate(batteryReset) {
     def correctedTimezone = ""
+    def timeString = clockformat ? "HH:mm:ss" : "h:mm:ss aa"
 
     if (!(location.timeZone)) {
         correctedTimezone = TimeZone.getTimeZone("GMT")
@@ -296,18 +298,18 @@ def formatDate(batteryReset) {
         if (batteryReset)
             return new Date().format("MMM dd yyyy", correctedTimezone)
         else
-            return new Date().format("EEE MMM dd yyyy h:mm:ss a", correctedTimezone)
+            return new Date().format("EEE MMM dd yyyy ${timeString}", correctedTimezone)
     }
     else if (dateformat == "UK") {
         if (batteryReset)
             return new Date().format("dd MMM yyyy", correctedTimezone)
         else
-            return new Date().format("EEE dd MMM yyyy h:mm:ss a", correctedTimezone)
+            return new Date().format("EEE dd MMM yyyy ${timeString}", correctedTimezone)
         }
     else {
         if (batteryReset)
             return new Date().format("yyyy MMM dd", correctedTimezone)
         else
-            return new Date().format("EEE yyyy MMM dd h:mm:ss a", correctedTimezone)
+            return new Date().format("EEE yyyy MMM dd ${timeString}", correctedTimezone)
     }
 }

--- a/devicetypes/bspranger/xiaomi-aqara-motion-sensor.src/xiaomi-aqara-motion-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-motion-sensor.src/xiaomi-aqara-motion-sensor.groovy
@@ -57,6 +57,7 @@ metadata {
     preferences {
         input name: "motionReset", "number", title: "Number of seconds after the last reported activity to report that motion is inactive (in seconds). \n\n(The device will always remain blind to motion for 60seconds following first detected motion. This value just clears the 'active' status after the number of seconds you set here but the device will still remain blind for 60seconds in normal operation.)", description: "", value:120, displayDuringSetup: true
 	input name: "dateformat", type: "enum", title: "Set Date Format\n US (MDY) - UK (DMY) - Other (YMD)", description: "Date Format", required: false, options:["US","UK","Other"]
+	input name: "clockformat", type: "bool", title: "Use 24 hour clock?", defaultValue: false, required: false
 	input description: "Only change the settings below if you know what you're doing", displayDuringSetup: false, type: "paragraph", element: "paragraph", title: "ADVANCED SETTINGS"
 	input name: "voltsmax", title: "Max Volts\nA battery is at 100% at __ volts\nRange 2.8 to 3.4", type: "decimal", range: "2.8..3.4", defaultValue: 3, required: false
 	input name: "voltsmin", title: "Min Volts\nA battery is at 0% (needs replacing) at __ volts\nRange 2.0 to 2.7", type: "decimal", range: "2..2.7", defaultValue: 2.5, required: false
@@ -351,6 +352,7 @@ private checkIntervalEvent(text) {
 
 def formatDate(batteryReset) {
     def correctedTimezone = ""
+    def timeString = clockformat ? "HH:mm:ss" : "h:mm:ss aa"
 
     if (!(location.timeZone)) {
         correctedTimezone = TimeZone.getTimeZone("GMT")
@@ -364,18 +366,18 @@ def formatDate(batteryReset) {
         if (batteryReset)
             return new Date().format("MMM dd yyyy", correctedTimezone)
         else
-            return new Date().format("EEE MMM dd yyyy h:mm:ss a", correctedTimezone)
+            return new Date().format("EEE MMM dd yyyy ${timeString}", correctedTimezone)
     }
     else if (dateformat == "UK") {
         if (batteryReset)
             return new Date().format("dd MMM yyyy", correctedTimezone)
         else
-            return new Date().format("EEE dd MMM yyyy h:mm:ss a", correctedTimezone)
+            return new Date().format("EEE dd MMM yyyy ${timeString}", correctedTimezone)
         }
     else {
         if (batteryReset)
             return new Date().format("yyyy MMM dd", correctedTimezone)
         else
-            return new Date().format("EEE yyyy MMM dd h:mm:ss a", correctedTimezone)
+            return new Date().format("EEE yyyy MMM dd ${timeString}", correctedTimezone)
     }
 }

--- a/devicetypes/bspranger/xiaomi-aqara-temperature-humidity-sensor.src/xiaomi-aqara-temperature-humidity-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-temperature-humidity-sensor.src/xiaomi-aqara-temperature-humidity-sensor.groovy
@@ -77,6 +77,7 @@ metadata {
         }
 	section {    
 	input name: "dateformat", type: "enum", title: "Set Date Format\n US (MDY) - UK (DMY) - Other (YMD)", description: "Date Format", required: false, options:["US","UK","Other"]
+	input name: "clockformat", type: "bool", title: "Use 24 hour clock?", defaultValue: false, required: false
 	input description: "Only change the settings below if you know what you're doing", displayDuringSetup: false, type: "paragraph", element: "paragraph", title: "ADVANCED SETTINGS"
 	input name: "voltsmax", title: "Max Volts\nA battery is at 100% at __ volts\nRange 2.8 to 3.4", type: "decimal", range: "2.8..3.4", defaultValue: 3, required: false
 	input name: "voltsmin", title: "Min Volts\nA battery is at 0% (needs replacing) at __ volts\nRange 2.0 to 2.7", type: "decimal", range: "2..2.7", defaultValue: 2.5, required: false
@@ -438,6 +439,7 @@ private checkIntervalEvent(text) {
 
 def formatDate(batteryReset) {
     def correctedTimezone = ""
+    def timeString = clockformat ? "HH:mm:ss" : "h:mm:ss aa"
 
     if (!(location.timeZone)) {
         correctedTimezone = TimeZone.getTimeZone("GMT")
@@ -451,18 +453,18 @@ def formatDate(batteryReset) {
         if (batteryReset)
             return new Date().format("MMM dd yyyy", correctedTimezone)
         else
-            return new Date().format("EEE MMM dd yyyy h:mm:ss a", correctedTimezone)
+            return new Date().format("EEE MMM dd yyyy ${timeString}", correctedTimezone)
     }
     else if (dateformat == "UK") {
         if (batteryReset)
             return new Date().format("dd MMM yyyy", correctedTimezone)
         else
-            return new Date().format("EEE dd MMM yyyy h:mm:ss a", correctedTimezone)
+            return new Date().format("EEE dd MMM yyyy ${timeString}", correctedTimezone)
         }
     else {
         if (batteryReset)
             return new Date().format("yyyy MMM dd", correctedTimezone)
         else
-            return new Date().format("EEE yyyy MMM dd h:mm:ss a", correctedTimezone)
+            return new Date().format("EEE yyyy MMM dd ${timeString}", correctedTimezone)
     }
 }

--- a/devicetypes/bspranger/xiaomi-button.src/xiaomi-button.groovy
+++ b/devicetypes/bspranger/xiaomi-button.src/xiaomi-button.groovy
@@ -44,6 +44,7 @@ preferences {
 	input ("holdTime", "number", title: "Minimum time in seconds for a press to count as \"held\"", defaultValue: 4, displayDuringSetup: false)
         input name: "PressType", type: "enum", options: ["Toggle", "Momentary"], description: "Effects how the button toggles", defaultValue: "Toggle", displayDuringSetup: true
     	input name: "dateformat", type: "enum", title: "Set Date Format\n US (MDY) - UK (DMY) - Other (YMD)", description: "Date Format", required: false, options:["US","UK","Other"]
+	input name: "clockformat", type: "bool", title: "Use 24 hour clock?", defaultValue: false, required: false
 	input description: "Only change the settings below if you know what you're doing", displayDuringSetup: false, type: "paragraph", element: "paragraph", title: "ADVANCED SETTINGS"
 	input name: "voltsmax", title: "Max Volts\nA battery is at 100% at __ volts\nRange 2.8 to 3.4", type: "decimal", range: "2.8..3.4", defaultValue: 3, required: false
 	input name: "voltsmin", title: "Min Volts\nA battery is at 0% (needs replacing) at __ volts\nRange 2.0 to 2.7", type: "decimal", range: "2..2.7", defaultValue: 2.5, required: false
@@ -326,6 +327,7 @@ private checkIntervalEvent(text) {
 
 def formatDate(batteryReset) {
     def correctedTimezone = ""
+    def timeString = clockformat ? "HH:mm:ss" : "h:mm:ss aa"
 
     if (!(location.timeZone)) {
         correctedTimezone = TimeZone.getTimeZone("GMT")
@@ -339,18 +341,18 @@ def formatDate(batteryReset) {
         if (batteryReset)
             return new Date().format("MMM dd yyyy", correctedTimezone)
         else
-            return new Date().format("EEE MMM dd yyyy h:mm:ss a", correctedTimezone)
+            return new Date().format("EEE MMM dd yyyy ${timeString}", correctedTimezone)
     }
     else if (dateformat == "UK") {
         if (batteryReset)
             return new Date().format("dd MMM yyyy", correctedTimezone)
         else
-            return new Date().format("EEE dd MMM yyyy h:mm:ss a", correctedTimezone)
+            return new Date().format("EEE dd MMM yyyy ${timeString}", correctedTimezone)
         }
     else {
         if (batteryReset)
             return new Date().format("yyyy MMM dd", correctedTimezone)
         else
-            return new Date().format("EEE yyyy MMM dd h:mm:ss a", correctedTimezone)
+            return new Date().format("EEE yyyy MMM dd ${timeString}", correctedTimezone)
     }
 }

--- a/devicetypes/bspranger/xiaomi-door-window-sensor.src/xiaomi-door-window-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-door-window-sensor.src/xiaomi-door-window-sensor.groovy
@@ -28,6 +28,7 @@
  */
 preferences {
 	input name: "dateformat", type: "enum", title: "Set Date Format\n US (MDY) - UK (DMY) - Other (YMD)", description: "Date Format", required: false, options:["US","UK","Other"]
+	input name: "clockformat", type: "bool", title: "Use 24 hour clock?", defaultValue: false, required: false
 	input description: "Only change the settings below if you know what you're doing", displayDuringSetup: false, type: "paragraph", element: "paragraph", title: "ADVANCED SETTINGS"
 	input name: "voltsmax", title: "Max Volts\nA battery is at 100% at __ volts\nRange 2.8 to 3.4", type: "decimal", range: "2.8..3.4", defaultValue: 3, required: false
 	input name: "voltsmin", title: "Min Volts\nA battery is at 0% (needs replacing) at __ volts\nRange 2.0 to 2.7", type: "decimal", range: "2..2.7", defaultValue: 2.5, required: false
@@ -283,6 +284,7 @@ private checkIntervalEvent(text) {
 
 def formatDate(batteryReset) {
     def correctedTimezone = ""
+    def timeString = clockformat ? "HH:mm:ss" : "h:mm:ss aa"
 
     if (!(location.timeZone)) {
         correctedTimezone = TimeZone.getTimeZone("GMT")
@@ -296,18 +298,18 @@ def formatDate(batteryReset) {
         if (batteryReset)
             return new Date().format("MMM dd yyyy", correctedTimezone)
         else
-            return new Date().format("EEE MMM dd yyyy h:mm:ss a", correctedTimezone)
+            return new Date().format("EEE MMM dd yyyy ${timeString}", correctedTimezone)
     }
     else if (dateformat == "UK") {
         if (batteryReset)
             return new Date().format("dd MMM yyyy", correctedTimezone)
         else
-            return new Date().format("EEE dd MMM yyyy h:mm:ss a", correctedTimezone)
+            return new Date().format("EEE dd MMM yyyy ${timeString}", correctedTimezone)
         }
     else {
         if (batteryReset)
             return new Date().format("yyyy MMM dd", correctedTimezone)
         else
-            return new Date().format("EEE yyyy MMM dd h:mm:ss a", correctedTimezone)
+            return new Date().format("EEE yyyy MMM dd ${timeString}", correctedTimezone)
     }
 }

--- a/devicetypes/bspranger/xiaomi-motion-sensor.src/xiaomi-motion-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-motion-sensor.src/xiaomi-motion-sensor.groovy
@@ -53,6 +53,7 @@ metadata {
 	preferences {
 		input "motionReset", "number", title: "Number of seconds after the last reported activity to report that motion is inactive (in seconds). \n\n(The device will always remain blind to motion for 60seconds following first detected motion. This value just clears the 'active' status after the number of seconds you set here but the device will still remain blind for 60seconds in normal operation.)", description: "", value:120, displayDuringSetup: true
 		input name: "dateformat", type: "enum", title: "Set Date Format\n US (MDY) - UK (DMY) - Other (YMD)", description: "Date Format", required: false, options:["US","UK","Other"]
+		input name: "clockformat", type: "bool", title: "Use 24 hour clock?", defaultValue: false, required: false
 		input description: "Only change the settings below if you know what you're doing", displayDuringSetup: false, type: "paragraph", element: "paragraph", title: "ADVANCED SETTINGS"
 		input name: "voltsmax", title: "Max Volts\nA battery is at 100% at __ volts\nRange 2.8 to 3.4", type: "decimal", range: "2.8..3.4", defaultValue: 3, required: false
 		input name: "voltsmin", title: "Min Volts\nA battery is at 0% (needs replacing) at __ volts\nRange 2.0 to 2.7", type: "decimal", range: "2..2.7", defaultValue: 2.5, required: false
@@ -331,6 +332,7 @@ private checkIntervalEvent(text) {
 
 def formatDate(batteryReset) {
     def correctedTimezone = ""
+    def timeString = clockformat ? "HH:mm:ss" : "h:mm:ss aa"
 
     if (!(location.timeZone)) {
         correctedTimezone = TimeZone.getTimeZone("GMT")
@@ -344,18 +346,18 @@ def formatDate(batteryReset) {
         if (batteryReset)
             return new Date().format("MMM dd yyyy", correctedTimezone)
         else
-            return new Date().format("EEE MMM dd yyyy h:mm:ss a", correctedTimezone)
+            return new Date().format("EEE MMM dd yyyy ${timeString}", correctedTimezone)
     }
     else if (dateformat == "UK") {
         if (batteryReset)
             return new Date().format("dd MMM yyyy", correctedTimezone)
         else
-            return new Date().format("EEE dd MMM yyyy h:mm:ss a", correctedTimezone)
+            return new Date().format("EEE dd MMM yyyy ${timeString}", correctedTimezone)
         }
     else {
         if (batteryReset)
             return new Date().format("yyyy MMM dd", correctedTimezone)
         else
-            return new Date().format("EEE yyyy MMM dd h:mm:ss a", correctedTimezone)
+            return new Date().format("EEE yyyy MMM dd ${timeString}", correctedTimezone)
     }
 }

--- a/devicetypes/bspranger/xiaomi-temperature-humidity-sensor.src/xiaomi-temperature-humidity-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-temperature-humidity-sensor.src/xiaomi-temperature-humidity-sensor.groovy
@@ -68,6 +68,7 @@ metadata {
         }
         section {
 		input name: "dateformat", type: "enum", title: "Set Date Format\n US (MDY) - UK (DMY) - Other (YMD)", description: "Date Format", required: false, options:["US","UK","Other"]
+		input name: "clockformat", type: "bool", title: "Use 24 hour clock?", defaultValue: false, required: false
 		input description: "Only change the settings below if you know what you're doing", displayDuringSetup: false, type: "paragraph", element: "paragraph", title: "ADVANCED SETTINGS"
 		input name: "voltsmax", title: "Max Volts\nA battery is at 100% at __ volts\nRange 2.8 to 3.4", type: "decimal", range: "2.8..3.4", defaultValue: 3, required: false
 		input name: "voltsmin", title: "Min Volts\nA battery is at 0% (needs replacing) at __ volts\nRange 2.0 to 2.7", type: "decimal", range: "2..2.7", defaultValue: 2.5, required: false
@@ -376,6 +377,7 @@ private checkIntervalEvent(text) {
 
 def formatDate(batteryReset) {
     def correctedTimezone = ""
+    def timeString = clockformat ? "HH:mm:ss" : "h:mm:ss aa"
 
     if (!(location.timeZone)) {
         correctedTimezone = TimeZone.getTimeZone("GMT")
@@ -389,18 +391,18 @@ def formatDate(batteryReset) {
         if (batteryReset)
             return new Date().format("MMM dd yyyy", correctedTimezone)
         else
-            return new Date().format("EEE MMM dd yyyy h:mm:ss a", correctedTimezone)
+            return new Date().format("EEE MMM dd yyyy ${timeString}", correctedTimezone)
     }
     else if (dateformat == "UK") {
         if (batteryReset)
             return new Date().format("dd MMM yyyy", correctedTimezone)
         else
-            return new Date().format("EEE dd MMM yyyy h:mm:ss a", correctedTimezone)
+            return new Date().format("EEE dd MMM yyyy ${timeString}", correctedTimezone)
         }
     else {
         if (batteryReset)
             return new Date().format("yyyy MMM dd", correctedTimezone)
         else
-            return new Date().format("EEE yyyy MMM dd h:mm:ss a", correctedTimezone)
+            return new Date().format("EEE yyyy MMM dd ${timeString}", correctedTimezone)
     }
 }


### PR DESCRIPTION
User cscheiene on SmartThings Community requested a 12/24 hour clock time format preference setting, and after checking, I see that SmartThings hasn't implemented this as a global setting based on the clock format of the host ST mobile app. Plenty of ST users personally prefer to use or live in places that use the 24 hour clock format.

So I've added it, with the setting just below the date format preference.

Tested on my DWS and leak sensor device handlers, works perfectly.