### PR TITLE
Add background colors to Humidity tile

### DIFF
--- a/devicetypes/bspranger/xiaomi-aqara-temperature-humidity-sensor.src/xiaomi-aqara-temperature-humidity-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-temperature-humidity-sensor.src/xiaomi-aqara-temperature-humidity-sensor.groovy
@@ -108,7 +108,7 @@ metadata {
                 )
             }
         }
-        standardTile("humidity", "device.humidity", inactiveLabel: false, decoration:"flat", width: 2, height: 2) {
+        valueTile("humidity", "device.humidity", inactiveLabel: false, decoration:"flat", width: 2, height: 2) {
             state "default", label:'${currentValue}%', unit:"%", icon:"st.Weather.weather12",
             backgroundColors:[
                 [value: 0, color: "#FFFCDF"],

--- a/devicetypes/bspranger/xiaomi-aqara-temperature-humidity-sensor.src/xiaomi-aqara-temperature-humidity-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-temperature-humidity-sensor.src/xiaomi-aqara-temperature-humidity-sensor.groovy
@@ -109,7 +109,16 @@ metadata {
             }
         }
         standardTile("humidity", "device.humidity", inactiveLabel: false, decoration:"flat", width: 2, height: 2) {
-            state "default", label:'${currentValue}%', unit:"%", icon:"st.Weather.weather12"
+            state "default", label:'${currentValue}%', unit:"%", icon:"st.Weather.weather12",
+            backgroundColors:[
+                [value: 0, color: "#FFFCDF"],
+                [value: 4, color: "#FDF789"],
+                [value: 20, color: "#A5CF63"],
+                [value: 23, color: "#6FBD7F"],
+                [value: 56, color: "#4CA98C"],
+                [value: 59, color: "#0072BB"],
+                [value: 76, color: "#085396"]
+            ]
         }
         standardTile("pressure", "device.pressure", inactiveLabel: false, decoration:"flat", width: 2, height: 2) {
             state "default", label:'${currentValue}', icon:"st.Weather.weather1"

--- a/devicetypes/bspranger/xiaomi-temperature-humidity-sensor.src/xiaomi-temperature-humidity-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-temperature-humidity-sensor.src/xiaomi-temperature-humidity-sensor.groovy
@@ -104,8 +104,17 @@ metadata {
                 attributeState("default", label:'Last Update: ${currentValue}', icon: "st.Health & Wellness.health9")
             }
         }
-        standardTile("humidity", "device.humidity", inactiveLabel: false, decoration: "flat", width: 2, height: 2) {
-            state "default", label:'${currentValue}%', icon:"st.Weather.weather12"
+        valueTile("humidity", "device.humidity", inactiveLabel: false, decoration: "flat", width: 2, height: 2) {
+            state "default", label:'${currentValue}%', icon:"st.Weather.weather12",
+            backgroundColors:[
+                [value: 0, color: "#FFFCDF"],
+                [value: 4, color: "#FDF789"],
+                [value: 20, color: "#A5CF63"],
+                [value: 23, color: "#6FBD7F"],
+                [value: 56, color: "#4CA98C"],
+                [value: 59, color: "#0072BB"],
+                [value: 76, color: "#085396"]
+            ]
         }
         
         valueTile("battery", "device.battery", decoration: "flat", inactiveLabel: false, width: 2, height: 2) {


### PR DESCRIPTION
@alecm suggested this change in Issue #66, and I inadvertently delayed it by trying to add custom icons for the humidity & battery tiles. We're having trouble getting custom icons to display between the different ST mobile app platforms, so I'm putting in this pull for Alec. We can try to figure out the custom icon thing later.

I think the color choices based on a known standard looks great, and @bspranger said he liked it, so unless anyone else thinks it should be different, I'll push it in tomorrow.