### PR TITLE
Standardisation

### DIFF
--- a/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
@@ -99,7 +99,7 @@ metadata {
    preferences {
 	section {	
 		input name:"ReleaseTime", type:"number", title:"Minimum time in seconds for a press to clear", defaultValue: 2
-        	input name:"PressType", type:"enum", options:["Toggle", "Momentary"], description:"Effects how the button toggles", defaultValue:"Toggle"
+        	input name: "PressType", type: "enum", options: ["Momentary", "Toggle"], title: "Momentary or toggle? ", defaultValue: "Momentary"
 		}
 	section {
 		input description: "", type: "paragraph", element: "paragraph", title: "DATE & CLOCK"    

--- a/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
@@ -223,7 +223,9 @@ private Map parseCatchAllMessage(String description) {
 
 // Convert raw 4 digit integer voltage value into percentage based on minVolts/maxVolts range
 private Map getBatteryResult(rawValue) {
-    def rawVolts = rawValue / 1000
+    // raw voltage is normally supplied as a 4 digit integer that needs to be divided by 1000
+    // but in the case the final zero is dropped then divide by 100 to get actual voltage value 
+    def rawVolts = (rawValue < 1000) ? (rawValue / 100) : (rawValue / 1000)
     def minVolts
     def maxVolts
 

--- a/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
@@ -98,7 +98,7 @@ metadata {
 		//Date & Time Config
 		input description: "", type: "paragraph", element: "paragraph", title: "DATE & CLOCK"    
 		input name: "dateformat", type: "enum", title: "Set Date Format\n US (MDY) - UK (DMY) - Other (YMD)", description: "Date Format", options:["US","UK","Other"]
-		input name: "clockformat", type: "bool", title: "Use 24 hour clock?", defaultValue: false
+		input name: "clockformat", type: "bool", title: "Use 24 hour clock?"
 		//Battery Reset Config
             	input description: "If you have installed a new battery, the toggle below will reset the Changed Battery date to help remember when it was changed.", type: "paragraph", element: "paragraph", title: "CHANGED BATTERY DATE RESET"
 		input name: "battReset", type: "bool", title: "Battery Changed?", description: ""

--- a/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
@@ -210,8 +210,8 @@ private Map parseCatchAllMessage(String description) {
 				if (catchall.data.get(i) == 0x21) { // check the data ID and data type
 					// next two bytes are the battery voltage
 					resultMap = getBatteryResult((catchall.data.get(i+2)<<8) + catchall.data.get(i+1))
+					break
 				}
-			break
 			}
 		}
 	}
@@ -222,7 +222,7 @@ private Map parseCatchAllMessage(String description) {
 private Map getBatteryResult(rawValue) {
     // raw voltage is normally supplied as a 4 digit integer that needs to be divided by 1000
     // but in the case the final zero is dropped then divide by 100 to get actual voltage value 
-    def rawVolts = (rawValue < 1000) ? (rawValue / 100) : (rawValue / 1000)
+    def rawVolts = rawValue / 1000
     def minVolts
     def maxVolts
 

--- a/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
@@ -101,7 +101,7 @@ metadata {
 		input name: "clockformat", type: "bool", title: "Use 24 hour clock?"
 		//Battery Reset Config
             	input description: "If you have installed a new battery, the toggle below will reset the Changed Battery date to help remember when it was changed.", type: "paragraph", element: "paragraph", title: "CHANGED BATTERY DATE RESET"
-		input name: "battReset", type: "bool", title: "Battery Changed?", description: ""
+		input name: "battReset", type: "bool", title: "Battery Changed?"
 		//Battery Voltage Offset
             	input description: "Only change the settings below if you know what you're doing.", type: "paragraph", element: "paragraph", title: "ADVANCED SETTINGS"
 		input name: "voltsmax", title: "Max Volts\nA battery is at 100% at __ volts\nRange 2.8 to 3.4", type: "decimal", range: "2.8..3.4", defaultValue: 3, required: false
@@ -316,6 +316,7 @@ def configure() {
     checkIntervalEvent("configure");
 }
 
+// installed() runs just after a sensor is paired using the "Add a Thing" method in the SmartThings mobile app
 def installed() {
     state.battery = 0
     resetBatteryRuntime()

--- a/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
@@ -306,33 +306,37 @@ private Map getContactResult(value) {
     ]
 }
 
-def resetBatteryRuntime() {
-    def now = formatDate(true)
-    sendEvent(name: "batteryRuntime", value: now)
-}
-
-def configure() {
-    log.debug "${device.displayName}: configuring"
-    state.battery = 0
-    state.button = "released"
-    checkIntervalEvent("configure");
+//Reset the date displayed in Battery Changed tile to current date
+def resetBatteryRuntime(paired) {
+	def now = formatDate(true)
+	def newlyPaired = paired ? " for newly paired sensor" : ""
+	sendEvent(name: "batteryRuntime", value: now)
+	log.debug "${device.displayName}: Setting Battery Changed to current date${newlyPaired}"
 }
 
 // installed() runs just after a sensor is paired using the "Add a Thing" method in the SmartThings mobile app
 def installed() {
-    state.battery = 0
-    resetBatteryRuntime()
-    state.button = "released"
-    checkIntervalEvent("installed");
+	state.battery = 0
+	if (!batteryRuntime) resetBatteryRuntime(true)
+	checkIntervalEvent("installed")
+}
+
+// configure() runs after installed() when a sensor is paired
+def configure() {
+	log.debug "${device.displayName}: configuring"
+		state.battery = 0
+	if (!batteryRuntime) resetBatteryRuntime(true)
+	checkIntervalEvent("configured")
+	return
 }
 
 // updated() will run twice every time user presses save in preference settings page
 def updated() {
-    checkIntervalEvent("updated");
-    if(battReset){
-	resetBatteryRuntime()
-	device.updateSetting("battReset", false)
-    }
+		checkIntervalEvent("updated")
+		if(battReset){
+		resetBatteryRuntime()
+		device.updateSetting("battReset", false)
+	}
 }
 
 private checkIntervalEvent(text) {

--- a/devicetypes/bspranger/xiaomi-aqara-door-window-sensor.src/xiaomi-aqara-door-window-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-door-window-sensor.src/xiaomi-aqara-door-window-sensor.groovy
@@ -1,5 +1,6 @@
 /**
  *  Xiaomi Aqara Door/Window Sensor
+ *  Version 1.0
  *
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -11,27 +12,14 @@
  *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
  *  for the specific language governing permissions and limitations under the License.
  *
- *  Based on original DH by Eric Maycock 2015 and Rave from Lazcad
+ *  Original device handler code by a4refillpad, adapted for use with Aqara model by bspranger
+ *  Additional contributions to code by alecm, alixjg, bspranger, gn0st1c, foz333, jmagnuson, rinkek, ronvandegraaf, snalee, tmleafs, twonk, & veeceeoh 
+ * 
+ *  Known issues:
+ *  Xiaomi sensors do not seem to respond to refresh requests
+ *  Inconsistent rendering of user interface text/graphics between iOS and Android devices - This is due to SmartThings, not this device handler
+ *  Pairing Xiaomi sensors can be difficult as they were not designed to use with a SmartThings hub. See 
  *
- *  Change log:
- *  Added DH Colours
- *  Added 100% battery max
- *  Fixed battery parsing problem
- *  Added lastcheckin attribute and tile
- *  Added extra tile to show when last opened
- *  Colours to confirm to new smartthings standards
- *  Added ability to force override current state to Open or Closed.
- *  Added experimental health check as worked out by rolled54.Why
- *  bspranger - Adding Aqara Support
- *  Rinkelk - added date-attribute support for Webcore
- *  Rinkelk - Changed battery percentage with code from cancrusher
- *  Rinkelk - Changed battery icon according to Mobile785
- *  sulee - Added endpointId copied from GvnCampbell's DH - Detects sensor when adding
- *  sulee - Track battery as average of min and max over time
- *  sulee - Clean up some of the code
- *  bspranger - renamed to bspranger to remove confusion of a4refillpad
- *  veeceeoh - added battery parse on button press
- *  veeceoh - added new refresh & configure code, fixed open/close override code
  */
 metadata {
     definition (name: "Xiaomi Aqara Door/Window Sensor", namespace: "bspranger", author: "bspranger") {
@@ -97,34 +85,35 @@ metadata {
 	details(["contact","battery","resetClosed","resetOpen","spacer","lastcheckin", "spacer", "spacer", "batteryRuntime", "spacer"])
    }
    preferences {
-	section {
+		//Date & Time Config
 		input description: "", type: "paragraph", element: "paragraph", title: "DATE & CLOCK"    
 		input name: "dateformat", type: "enum", title: "Set Date Format\n US (MDY) - UK (DMY) - Other (YMD)", description: "Date Format", options:["US","UK","Other"]
-		input name: "clockformat", type: "bool", title: "Use 24 hour clock?", defaultValue: false
-		}
-	section {
+		input name: "clockformat", type: "bool", title: "Use 24 hour clock?"
+		//Battery Reset Config
             	input description: "If you have installed a new battery, the toggle below will reset the Changed Battery date to help remember when it was changed.", type: "paragraph", element: "paragraph", title: "CHANGED BATTERY DATE RESET"
 		input name: "battReset", type: "bool", title: "Battery Changed?", description: ""
-		}
-	section {
+		//Battery Voltage Offset
 	        input description: "Only change the settings below if you know what you're doing.", type: "paragraph", element: "paragraph", title: "ADVANCED SETTINGS"
 		input name: "voltsmax", title: "Max Volts\nA battery is at 100% at __ volts\nRange 2.8 to 3.4", type: "decimal", range: "2.8..3.4", defaultValue: 3, required: false
 		input name: "voltsmin", title: "Min Volts\nA battery is at 0% (needs replacing) at __ volts\nRange 2.0 to 2.7", type: "decimal", range: "2..2.7", defaultValue: 2.5, required: false
-		}
   } 
 }
 
+// Parse incoming device messages to generate events
 def parse(String description) {
     def result = zigbee.getEvent(description)
 
-    // send event for heartbeat
+	// Determine current time and date in the user-selected date format and clock style
     def now = formatDate()    
     def nowDate = new Date(now).getTime()
+	// Any report - contact sensor & Battery - results in a lastCheckin event and update to Last Checkin tile
+	// However, only a non-parseable report results in lastCheckin being displayed in events log
     sendEvent(name: "lastCheckin", value: now, displayed: false)
     sendEvent(name: "lastCheckinDate", value: nowDate, displayed: false)
 
     Map map = [:]
 
+	// Send message data to appropriate parsing function based on the type of report	
     if (result) {
         log.debug "${device.displayName} Event: ${result}"
         map = getContactResult(result);
@@ -141,6 +130,7 @@ def parse(String description) {
     return results
 }
 
+// Convert raw 4 digit integer voltage value into percentage based on minVolts/maxVolts range
 private Map getBatteryResult(rawValue) {
     def rawVolts = rawValue / 1000
     def minVolts
@@ -171,6 +161,7 @@ private Map getBatteryResult(rawValue) {
     return result
 }
 
+// Check catchall for battery voltage data to pass to getBatteryResult for conversion to percentage report
 private Map parseCatchAllMessage(String description) {
     Map resultMap = [:]
     def i
@@ -264,6 +255,7 @@ def installed() {
     checkIntervalEvent("installed");
 }
 
+// updated() will run twice every time user presses save in preference settings page
 def updated() {
     checkIntervalEvent("updated");
 	if(battReset){
@@ -282,6 +274,7 @@ def formatDate(batteryReset) {
     def correctedTimezone = ""
     def timeString = clockformat ? "HH:mm:ss" : "h:mm:ss aa"
 
+	// If user's hub timezone is not set, display error messages in log and events log, and set timezone to GMT to avoid errors
     if (!(location.timeZone)) {
         correctedTimezone = TimeZone.getTimeZone("GMT")
         log.error "${device.displayName}: Time Zone not set, so GMT was used. Please set up your location in the SmartThings mobile app."

--- a/devicetypes/bspranger/xiaomi-aqara-door-window-sensor.src/xiaomi-aqara-door-window-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-door-window-sensor.src/xiaomi-aqara-door-window-sensor.groovy
@@ -136,7 +136,7 @@ def parse(String description) {
 private Map getBatteryResult(rawValue) {
     // raw voltage is normally supplied as a 4 digit integer that needs to be divided by 1000
     // but in the case the final zero is dropped then divide by 100 to get actual voltage value 
-    def rawVolts = (rawValue < 1000) ? (rawValue / 100) : (rawValue / 1000)
+    def rawVolts = rawValue / 1000
 
     def minVolts
     def maxVolts
@@ -180,8 +180,8 @@ private Map parseCatchAllMessage(String description) {
 				if (catchall.data.get(i) == 0x21) { // check the data ID and data type
 					// next two bytes are the battery voltage
 					resultMap = getBatteryResult((catchall.data.get(i+2)<<8) + catchall.data.get(i+1))
+					break
 				}
-			break
 			}
 		}
 	}

--- a/devicetypes/bspranger/xiaomi-aqara-door-window-sensor.src/xiaomi-aqara-door-window-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-door-window-sensor.src/xiaomi-aqara-door-window-sensor.groovy
@@ -220,26 +220,26 @@ private Map parseReadAttr(String description) {
     return resultMap
 }
 
-private Map getContactResult(result) {
-    def value = result.value == "on" ? "open" : "closed"
-    def descriptionText = "${device.displayName} was ${value == "open" ? value + "ed" : value}"
+private Map getContactResult(value) {
+    def descriptionText = "${device.displayName} was ${value == 'open' ? 'opened' : 'closed'}"
     return [
         name: 'contact',
         value: value,
+        isStateChange: true,
         descriptionText: descriptionText
     ]
 }
 
 def resetClosed() {
-    sendEvent(name:"contact", value:"closed")
-}
+    sendEvent(name: "contact", value: "closed", descriptionText: "${device.displayName} was manually reset to closed")
+} 
 
 def resetOpen() {
-    def now = formatDate() 
-    def nowDate = new Date(now).getTime()
-    sendEvent(name: "lastOpened", value: now, displayed: false)
-    sendEvent(name: "lastOpenedDate", value: nowDate, displayed: false)
-    sendEvent(name: "contact", value:"open")
+	def now = formatDate()
+	def nowDate = new Date(now).getTime()
+	sendEvent(name: "lastOpened", value: now, displayed: false)
+	sendEvent(name: "lastOpenedDate", value: nowDate, displayed: false) 
+	sendEvent(name: "contact", value: "open", descriptionText: "${device.displayName} was manually reset to open")
 }
 
 //Reset the date displayed in Battery Changed tile to current date

--- a/devicetypes/bspranger/xiaomi-aqara-door-window-sensor.src/xiaomi-aqara-door-window-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-door-window-sensor.src/xiaomi-aqara-door-window-sensor.groovy
@@ -91,7 +91,7 @@ metadata {
 		input name: "clockformat", type: "bool", title: "Use 24 hour clock?"
 		//Battery Reset Config
             	input description: "If you have installed a new battery, the toggle below will reset the Changed Battery date to help remember when it was changed.", type: "paragraph", element: "paragraph", title: "CHANGED BATTERY DATE RESET"
-		input name: "battReset", type: "bool", title: "Battery Changed?", description: ""
+		input name: "battReset", type: "bool", title: "Battery Changed?"
 		//Battery Voltage Offset
 	        input description: "Only change the settings below if you know what you're doing.", type: "paragraph", element: "paragraph", title: "ADVANCED SETTINGS"
 		input name: "voltsmax", title: "Max Volts\nA battery is at 100% at __ volts\nRange 2.8 to 3.4", type: "decimal", range: "2.8..3.4", defaultValue: 3, required: false
@@ -249,6 +249,7 @@ def configure() {
     return
 }
 
+// installed() runs just after a sensor is paired using the "Add a Thing" method in the SmartThings mobile app
 def installed() {
     state.battery = 0
     resetBatteryRuntime()

--- a/devicetypes/bspranger/xiaomi-aqara-door-window-sensor.src/xiaomi-aqara-door-window-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-door-window-sensor.src/xiaomi-aqara-door-window-sensor.groovy
@@ -220,8 +220,9 @@ private Map parseReadAttr(String description) {
     return resultMap
 }
 
-private Map getContactResult(value) {
-    def descriptionText = "${device.displayName} was ${value == 'open' ? 'opened' : 'closed'}"
+private Map getContactResult(result) {
+    def value = result.value == "on" ? "open" : "closed"
+    def descriptionText = "${device.displayName} was ${value == "open" ? value + "ed" : value}"
     return [
         name: 'contact',
         value: value,

--- a/devicetypes/bspranger/xiaomi-aqara-door-window-sensor.src/xiaomi-aqara-door-window-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-door-window-sensor.src/xiaomi-aqara-door-window-sensor.groovy
@@ -132,7 +132,10 @@ def parse(String description) {
 
 // Convert raw 4 digit integer voltage value into percentage based on minVolts/maxVolts range
 private Map getBatteryResult(rawValue) {
-    def rawVolts = rawValue / 1000
+    // raw voltage is normally supplied as a 4 digit integer that needs to be divided by 1000
+    // but in the case the final zero is dropped then divide by 100 to get actual voltage value 
+    def rawVolts = (rawValue < 1000) ? (rawValue / 100) : (rawValue / 1000)
+
     def minVolts
     def maxVolts
 

--- a/devicetypes/bspranger/xiaomi-aqara-leak-sensor.src/xiaomi-aqara-leak-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-leak-sensor.src/xiaomi-aqara-leak-sensor.groovy
@@ -65,6 +65,9 @@ metadata {
                 [value: 51, color: "#44b621"]
             ]
         }
+        valueTile("spacer", "spacer", decoration: "flat", inactiveLabel: false, width: 1, height: 1) {
+	    state "default", label:''
+        }
         valueTile("lastcheckin", "device.lastCheckin", decoration: "flat", inactiveLabel: false, width: 4, height: 1) {
             state "default", label:'Last Event:\n${currentValue}'
         }
@@ -79,7 +82,7 @@ metadata {
         }
 
         main (["water"])
-        details(["water","battery","resetDry","resetWet","lastcheckin","batteryRuntime"])
+        details(["water","battery","resetDry","resetWet", "spacer", "lastcheckin", "spacer", "spacer","batteryRuntime", "spacer"])
    }
    preferences {
 		//Date & Time Config

--- a/devicetypes/bspranger/xiaomi-aqara-leak-sensor.src/xiaomi-aqara-leak-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-leak-sensor.src/xiaomi-aqara-leak-sensor.groovy
@@ -150,8 +150,10 @@ private Map parseZoneStatusMessage(String description) {
 
 // Convert raw 4 digit integer voltage value into percentage based on minVolts/maxVolts range
 private Map getBatteryResult(rawValue) {
-    def rawVolts = rawValue / 1000
-	def minVolts
+    // raw voltage is normally supplied as a 4 digit integer that needs to be divided by 1000
+    // but in the case the final zero is dropped then divide by 100 to get actual voltage value 
+    def rawVolts = (rawValue < 1000) ? (rawValue / 100) : (rawValue / 1000)
+    def minVolts
     def maxVolts
 
     if(voltsmin == null || voltsmin == "")

--- a/devicetypes/bspranger/xiaomi-aqara-leak-sensor.src/xiaomi-aqara-leak-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-leak-sensor.src/xiaomi-aqara-leak-sensor.groovy
@@ -253,28 +253,34 @@ def resetWet() {
     sendEvent(name: "lastWetDate", value: nowDate, displayed: false)
 }
 
-def resetBatteryRuntime() {
-    def now = formatDate(true)    
-    sendEvent(name: "batteryRuntime", value: now)
-}
-
-def configure() {
-    log.debug "${device.displayName}: configuring"
-    state.battery = 0
-    checkIntervalEvent("configure");
+//Reset the date displayed in Battery Changed tile to current date
+def resetBatteryRuntime(paired) {
+	def now = formatDate(true)
+	def newlyPaired = paired ? " for newly paired sensor" : ""
+	sendEvent(name: "batteryRuntime", value: now)
+	log.debug "${device.displayName}: Setting Battery Changed to current date${newlyPaired}"
 }
 
 // installed() runs just after a sensor is paired using the "Add a Thing" method in the SmartThings mobile app
 def installed() {
-    state.battery = 0
-    resetBatteryRuntime()
-    checkIntervalEvent("installed");
+	state.battery = 0
+	if (!batteryRuntime) resetBatteryRuntime(true)
+	checkIntervalEvent("installed")
+}
+
+// configure() runs after installed() when a sensor is paired
+def configure() {
+	log.debug "${device.displayName}: configuring"
+		state.battery = 0
+	if (!batteryRuntime) resetBatteryRuntime(true)
+	checkIntervalEvent("configured")
+	return
 }
 
 // updated() will run twice every time user presses save in preference settings page
 def updated() {
-    checkIntervalEvent("updated");
-	if(battReset){
+		checkIntervalEvent("updated")
+		if(battReset){
 		resetBatteryRuntime()
 		device.updateSetting("battReset", false)
 	}

--- a/devicetypes/bspranger/xiaomi-aqara-leak-sensor.src/xiaomi-aqara-leak-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-leak-sensor.src/xiaomi-aqara-leak-sensor.groovy
@@ -155,7 +155,7 @@ private Map parseZoneStatusMessage(String description) {
 private Map getBatteryResult(rawValue) {
     // raw voltage is normally supplied as a 4 digit integer that needs to be divided by 1000
     // but in the case the final zero is dropped then divide by 100 to get actual voltage value 
-    def rawVolts = (rawValue < 1000) ? (rawValue / 100) : (rawValue / 1000)
+    def rawVolts = rawValue / 1000
     def minVolts
     def maxVolts
 
@@ -198,8 +198,8 @@ private Map parseCatchAllMessage(String description) {
 				if (catchall.data.get(i) == 0x21) { // check the data ID and data type
 					// next two bytes are the battery voltage
 					resultMap = getBatteryResult((catchall.data.get(i+2)<<8) + catchall.data.get(i+1))
+					break
 				}
-			break
 			}
 		}
 	}

--- a/devicetypes/bspranger/xiaomi-aqara-leak-sensor.src/xiaomi-aqara-leak-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-leak-sensor.src/xiaomi-aqara-leak-sensor.groovy
@@ -1,5 +1,6 @@
 /**
  *  Xiaomi Aqara Leak Sensor
+ *  Version 1.0
  *
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -11,27 +12,14 @@
  *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
  *  for the specific language governing permissions and limitations under the License.
  *
- *  Based on original DH by Eric Maycock 2015 and Rave from Lazcad
+ *  Original device handler code by a4refillpad, adapted for use with Aqara model by bspranger
+ *  Additional contributions to code by alecm, alixjg, bspranger, gn0st1c, foz333, jmagnuson, rinkek, ronvandegraaf, snalee, tmleafs, twonk, & veeceeoh 
+ * 
+ *  Known issues:
+ *  Xiaomi sensors do not seem to respond to refresh requests
+ *  Inconsistent rendering of user interface text/graphics between iOS and Android devices - This is due to SmartThings, not this device handler
+ *  Pairing Xiaomi sensors can be difficult as they were not designed to use with a SmartThings hub. See 
  *
- *  Change log:
- *  Added DH Colours
- *  Added 100% battery max
- *  Fixed battery parsing problem
- *  Added lastcheckin attribute and tile
- *  Added extra tile to show when last opened
- *  Colours to confirm to new smartthings standards
- *  Added ability to force override current state to Open or Closed.
- *  Added experimental health check as worked out by rolled54.Why
- *  bspranger - Adding Aqara Support
- *  Rinkelk - added date-attribute support for Webcore
- *  Rinkelk - Changed battery percentage with code from cancrusher
- *  Rinkelk - Changed battery icon according to Mobile785
- *  sulee - Added endpointId copied from GvnCampbell's DH - Detects sensor when adding
- *  sulee - Track battery as average of min and max over time
- *  sulee - Clean up some of the code
- *  bspranger - renamed to bspranger to remove confusion of a4refillpad
- *  veeceeoh - added battery parse on button press
- *  veeceeoh - added wet/dry override capability
  */
 metadata {
     definition (name: "Xiaomi Aqara Leak Sensor", namespace: "bspranger", author: "bspranger") {
@@ -94,34 +82,35 @@ metadata {
         details(["water","battery","resetDry","resetWet","lastcheckin","batteryRuntime"])
    }
    preferences {
-	section {
+		//Date & Time Config
 		input description: "", type: "paragraph", element: "paragraph", title: "DATE & CLOCK"    
 		input name: "dateformat", type: "enum", title: "Set Date Format\n US (MDY) - UK (DMY) - Other (YMD)", description: "Date Format", options:["US","UK","Other"]
-		input name: "clockformat", type: "bool", title: "Use 24 hour clock?", defaultValue: false
-		}
-	section {
+		input name: "clockformat", type: "bool", title: "Use 24 hour clock?"
+		//Battery Reset Config
             	input description: "If you have installed a new battery, the toggle below will reset the Changed Battery date to help remember when it was changed.", type: "paragraph", element: "paragraph", title: "CHANGED BATTERY DATE RESET"
 		input name: "battReset", type: "bool", title: "Battery Changed?", description: ""
-		}
-	section {
+		//Battery Voltage Offset
 	        input description: "Only change the settings below if you know what you're doing.", type: "paragraph", element: "paragraph", title: "ADVANCED SETTINGS"
 		input name: "voltsmax", title: "Max Volts\nA battery is at 100% at __ volts\nRange 2.8 to 3.4", type: "decimal", range: "2.8..3.4", defaultValue: 3, required: false
 		input name: "voltsmin", title: "Min Volts\nA battery is at 0% (needs replacing) at __ volts\nRange 2.0 to 2.7", type: "decimal", range: "2..2.7", defaultValue: 2.5, required: false
-		}
-  } 
+   } 
 }
 
+// Parse incoming device messages to generate events
 def parse(String description) {
     log.debug "${device.displayName} Description:${description}"
 
-    // send event for heartbeat
+	// Determine current time and date in the user-selected date format and clock style
     def now = formatDate()    
     def nowDate = new Date(now).getTime()
+	// Any report - wet sensor & Battery - results in a lastCheckin event and update to Last Checkin tile
+	// However, only a non-parseable report results in lastCheckin being displayed in events log
     sendEvent(name: "lastCheckin", value: now, displayed: false)
     sendEvent(name: "lastCheckinDate", value: nowDate, displayed: false)
 
     Map map = [:]
 
+	// Send message data to appropriate parsing function based on the type of report	
     if (description?.startsWith('zone status')) {
         map = parseZoneStatusMessage(description)
         if (map.value == "wet") {
@@ -159,6 +148,7 @@ private Map parseZoneStatusMessage(String description) {
     return [:]
 }
 
+// Convert raw 4 digit integer voltage value into percentage based on minVolts/maxVolts range
 private Map getBatteryResult(rawValue) {
     def rawVolts = rawValue / 1000
 	def minVolts
@@ -189,6 +179,7 @@ private Map getBatteryResult(rawValue) {
     return result
 }
 
+// Check catchall for battery voltage data to pass to getBatteryResult for conversion to percentage report
 private Map parseCatchAllMessage(String description) {
     Map resultMap = [:]
     def i
@@ -268,6 +259,7 @@ def configure() {
     checkIntervalEvent("configure");
 }
 
+// updated() will run twice every time user presses save in preference settings page
 def installed() {
     state.battery = 0
     resetBatteryRuntime()
@@ -292,6 +284,7 @@ def formatDate(batteryReset) {
     def correctedTimezone = ""
     def timeString = clockformat ? "HH:mm:ss" : "h:mm:ss aa"
 
+	// If user's hub timezone is not set, display error messages in log and events log, and set timezone to GMT to avoid errors
     if (!(location.timeZone)) {
         correctedTimezone = TimeZone.getTimeZone("GMT")
         log.error "${device.displayName}: Time Zone not set, so GMT was used. Please set up your location in the SmartThings mobile app."

--- a/devicetypes/bspranger/xiaomi-aqara-leak-sensor.src/xiaomi-aqara-leak-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-leak-sensor.src/xiaomi-aqara-leak-sensor.groovy
@@ -186,26 +186,24 @@ private Map getBatteryResult(rawValue) {
 
 // Check catchall for battery voltage data to pass to getBatteryResult for conversion to percentage report
 private Map parseCatchAllMessage(String description) {
-    Map resultMap = [:]
-    def i
-    def cluster = zigbee.parse(description)
-    log.debug "${device.displayName}: Parsing CatchAll: '${cluster}'"
+	Map resultMap = [:]
+	def catchall = zigbee.parse(description)
+	log.debug catchall
 
-    if (cluster) {
-        switch(cluster.clusterId) {
-            case 0x0000:
-                def MsgLength = cluster.data.size();
-                for (i = 0; i < (MsgLength-3); i++) {
-                    if ((cluster.data.get(i) == 0x01) && (cluster.data.get(i+1) == 0x21))  // check the data ID and data type
-                    {
-                        // next two bytes are the battery voltage.
-                        resultMap = getBatteryResult((cluster.data.get(i+3)<<8) + cluster.data.get(i+2))
-                    }
-                }
-            break
-        }
-    }
-    return resultMap
+	if (catchall.clusterId == 0x0000) {
+		def MsgLength = catchall.data.size()
+		// Xiaomi CatchAll does not have identifiers, first UINT16 is Battery
+		if ((catchall.data.get(0) == 0x01 || catchall.data.get(0) == 0x02) && (catchall.data.get(1) == 0xFF)) {
+			for (int i = 4; i < (MsgLength-3); i++) {
+				if (catchall.data.get(i) == 0x21) { // check the data ID and data type
+					// next two bytes are the battery voltage
+					resultMap = getBatteryResult((catchall.data.get(i+2)<<8) + catchall.data.get(i+1))
+				}
+			break
+			}
+		}
+	}
+	return resultMap
 }
 
 // Parse raw data on reset button press to retrieve reported battery voltage

--- a/devicetypes/bspranger/xiaomi-aqara-leak-sensor.src/xiaomi-aqara-leak-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-leak-sensor.src/xiaomi-aqara-leak-sensor.groovy
@@ -88,7 +88,7 @@ metadata {
 		input name: "clockformat", type: "bool", title: "Use 24 hour clock?"
 		//Battery Reset Config
             	input description: "If you have installed a new battery, the toggle below will reset the Changed Battery date to help remember when it was changed.", type: "paragraph", element: "paragraph", title: "CHANGED BATTERY DATE RESET"
-		input name: "battReset", type: "bool", title: "Battery Changed?", description: ""
+		input name: "battReset", type: "bool", title: "Battery Changed?"
 		//Battery Voltage Offset
 	        input description: "Only change the settings below if you know what you're doing.", type: "paragraph", element: "paragraph", title: "ADVANCED SETTINGS"
 		input name: "voltsmax", title: "Max Volts\nA battery is at 100% at __ volts\nRange 2.8 to 3.4", type: "decimal", range: "2.8..3.4", defaultValue: 3, required: false
@@ -259,13 +259,14 @@ def configure() {
     checkIntervalEvent("configure");
 }
 
-// updated() will run twice every time user presses save in preference settings page
+// installed() runs just after a sensor is paired using the "Add a Thing" method in the SmartThings mobile app
 def installed() {
     state.battery = 0
     resetBatteryRuntime()
     checkIntervalEvent("installed");
 }
 
+// updated() will run twice every time user presses save in preference settings page
 def updated() {
     checkIntervalEvent("updated");
 	if(battReset){

--- a/devicetypes/bspranger/xiaomi-aqara-motion-sensor.src/xiaomi-aqara-motion-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-motion-sensor.src/xiaomi-aqara-motion-sensor.groovy
@@ -95,7 +95,7 @@ metadata {
 		input name: "clockformat", type: "bool", title: "Use 24 hour clock?"
 		//Battery Reset Config
             	input description: "If you have installed a new battery, the toggle below will reset the Changed Battery date to help remember when it was changed.", type: "paragraph", element: "paragraph", title: "CHANGED BATTERY DATE RESET"
-		input name: "battReset", type: "bool", title: "Battery Changed?", description: ""
+		input name: "battReset", type: "bool", title: "Battery Changed?"
 		//Battery Voltage Offset
 	        input description: "Only change the settings below if you know what you're doing.", type: "paragraph", element: "paragraph", title: "ADVANCED SETTINGS"
 		input name: "voltsmax", title: "Max Volts\nA battery is at 100% at __ volts\nRange 2.8 to 3.4", type: "decimal", range: "2.8..3.4", defaultValue: 3, required: false

--- a/devicetypes/bspranger/xiaomi-aqara-motion-sensor.src/xiaomi-aqara-motion-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-motion-sensor.src/xiaomi-aqara-motion-sensor.groovy
@@ -195,8 +195,8 @@ private Map parseCatchAllMessage(String description) {
 				if (catchall.data.get(i) == 0x21) { // check the data ID and data type
 					// next two bytes are the battery voltage
 					resultMap = getBatteryResult((catchall.data.get(i+2)<<8) + catchall.data.get(i+1))
+					break
 				}
-			break
 			}
 		}
 	}
@@ -207,7 +207,7 @@ private Map parseCatchAllMessage(String description) {
 private Map getBatteryResult(rawValue) {
     // raw voltage is normally supplied as a 4 digit integer that needs to be divided by 1000
     // but in the case the final zero is dropped then divide by 100 to get actual voltage value 
-    def rawVolts = (rawValue < 1000) ? (rawValue / 100) : (rawValue / 1000)
+    def rawVolts = rawValue / 1000
 	def minVolts
     def maxVolts
 
@@ -240,7 +240,7 @@ def stopMotion() {
 	if (device.currentState('motion')?.value == "active") {
 		def seconds = motionreset ? motionreset : 60
 		sendEvent(name:"motion", value:"inactive", isStateChange: true)
-		log.debug "${device.displayName} reset to no motion after ${seconds}"
+		log.debug "${device.displayName} reset to no motion after ${seconds} seconds"
 	}
 }
 

--- a/devicetypes/bspranger/xiaomi-aqara-motion-sensor.src/xiaomi-aqara-motion-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-motion-sensor.src/xiaomi-aqara-motion-sensor.groovy
@@ -67,6 +67,9 @@ metadata {
                 [value: 51, color: "#44b621"]
             ]
         }
+        valueTile("spacer", "spacer", decoration: "flat", inactiveLabel: false, width: 1, height: 1) {
+	    state "default", label:''
+        }
         valueTile("illuminance", "device.illuminance", decoration:"flat", inactiveLabel: false, width: 2, height: 2) {
             state "default", label:'${currentValue} lux', unit:"lux"
         }
@@ -79,12 +82,9 @@ metadata {
         valueTile("batteryRuntime", "device.batteryRuntime", inactiveLabel: false, decoration:"flat", width: 4, height: 1) {
              state "batteryRuntime", label:'Battery Changed:\n ${currentValue}'
         }
-        standardTile("empty1x1", "null", width: 1, height: 1, decoration:"flat") {
-             state "emptySmall", label:"", defaultState: true
-        }
 
         main(["motion"])
-        details(["motion", "battery", "illuminance", "reset", "lastcheckin", "batteryRuntime"])
+        details(["motion", "battery", "illuminance", "reset", "spacer", "lastcheckin", "spacer", "spacer", "batteryRuntime", "spacer"])
     }
    preferences {
 		//motion Time out

--- a/devicetypes/bspranger/xiaomi-aqara-motion-sensor.src/xiaomi-aqara-motion-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-motion-sensor.src/xiaomi-aqara-motion-sensor.groovy
@@ -336,6 +336,7 @@ def configure() {
     checkIntervalEvent("configure");
 }
 
+// installed() runs just after a sensor is paired using the "Add a Thing" method in the SmartThings mobile app
 def installed() {
     state.battery = 0
     resetBatteryRuntime()

--- a/devicetypes/bspranger/xiaomi-aqara-motion-sensor.src/xiaomi-aqara-motion-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-motion-sensor.src/xiaomi-aqara-motion-sensor.groovy
@@ -107,7 +107,7 @@ metadata {
 def parse(String description) {
     log.debug "${device.displayName} Parsing: $description"
 
-	// Determine current time and date in the user-selected date format and clock style
+    // Determine current time and date in the user-selected date format and clock style
     def now = formatDate()    
     def nowDate = new Date(now).getTime()
 	// Any report - motion, lux & Battery - results in a lastCheckin event and update to Last Checkin tile
@@ -117,7 +117,7 @@ def parse(String description) {
 
     Map map = [:]
 	
-	// Send message data to appropriate parsing function based on the type of report	
+    // Send message data to appropriate parsing function based on the type of report	
     if (description?.startsWith('catchall:')) {
         map = parseCatchAllMessage(description)
     }
@@ -154,8 +154,10 @@ private Map parseIlluminanceMessage(String description) {
 
 // Convert raw 4 digit integer voltage value into percentage based on minVolts/maxVolts range
 private Map getBatteryResult(rawValue) {
-    def rawVolts = rawValue / 1000
-	def minVolts
+    // raw voltage is normally supplied as a 4 digit integer that needs to be divided by 1000
+    // but in the case the final zero is dropped then divide by 100 to get actual voltage value 
+    def rawVolts = (rawValue < 1000) ? (rawValue / 100) : (rawValue / 1000)
+    def minVolts
     def maxVolts
 
     if(voltsmin == null || voltsmin == "")

--- a/devicetypes/bspranger/xiaomi-aqara-motion-sensor.src/xiaomi-aqara-motion-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-motion-sensor.src/xiaomi-aqara-motion-sensor.groovy
@@ -1,5 +1,6 @@
 /**
  *  Xiaomi Aqara Motion Sensor
+ *  Version 1.0
  *
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -11,21 +12,14 @@
  *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
  *  for the specific language governing permissions and limitations under the License.
  *
- *  Based on original DH by Eric Maycock 2015
+ *  Original device handler code by a4refillpad, adapted for use with Aqara model by bspranger
+ *  Additional contributions to code by alecm, alixjg, bspranger, gn0st1c, foz333, jmagnuson, rinkek, ronvandegraaf, snalee, tmleafs, twonk, & veeceeoh 
+ * 
+ *  Known issues:
+ *  Xiaomi sensors do not seem to respond to refresh requests
+ *  Inconsistent rendering of user interface text/graphics between iOS and Android devices - This is due to SmartThings, not this device handler
+ *  Pairing Xiaomi sensors can be difficult as they were not designed to use with a SmartThings hub. See 
  *
- *  Change log:
- *  modified 29/12/2016 a4refillpad
- *  Added fingerprinting
- *  Added heartbeat/lastcheckin for monitoring
- *  Added battery and refresh
- *  Motion background colours consistent with latest DH
- *  Fixed max battery percentage to be 100%
- *  Added Last update to main tile
- *  Added last motion tile
- *  Heartdeat icon plus improved localisation of date
- *  Removed non working tiles and changed layout and incorporated latest colours
- *  Added experimental health check as worked out by rolled54.Why
- *  bspranger - renamed to bspranger to remove confusion of a4refillpad
  */
 
 metadata {
@@ -93,36 +87,37 @@ metadata {
         details(["motion", "battery", "illuminance", "reset", "lastcheckin", "batteryRuntime"])
     }
    preferences {
-	section {
-	        input name: "motionReset", "number", title: "Number of seconds after the last reported activity to report that motion is inactive (in seconds). \n\n(The device will always remain blind to motion for 60seconds following first detected motion. This value just clears the 'active' status after the number of seconds you set here but the device will still remain blind for 60seconds in normal operation.)", description: "", value:120, displayDuringSetup: true
-		}	 
-	section {
+		//motion Time out
+	        input name: "motionReset", "number", title: "Number of seconds after the last reported activity to report that motion is inactive (in seconds). \n\n(The device will always remain blind to motion for 60seconds following first detected motion. This value just clears the 'active' status after the number of seconds you set here but the device will still remain blind for 60seconds in normal operation.)", description: "", defaultValue:120
+		//Date & Time Config
 		input description: "", type: "paragraph", element: "paragraph", title: "DATE & CLOCK"    
 		input name: "dateformat", type: "enum", title: "Set Date Format\n US (MDY) - UK (DMY) - Other (YMD)", description: "Date Format", options:["US","UK","Other"]
-		input name: "clockformat", type: "bool", title: "Use 24 hour clock?", defaultValue: false
-		}
-	section {
+		input name: "clockformat", type: "bool", title: "Use 24 hour clock?"
+		//Battery Reset Config
             	input description: "If you have installed a new battery, the toggle below will reset the Changed Battery date to help remember when it was changed.", type: "paragraph", element: "paragraph", title: "CHANGED BATTERY DATE RESET"
 		input name: "battReset", type: "bool", title: "Battery Changed?", description: ""
-		}
-	section {
+		//Battery Voltage Offset
 	        input description: "Only change the settings below if you know what you're doing.", type: "paragraph", element: "paragraph", title: "ADVANCED SETTINGS"
 		input name: "voltsmax", title: "Max Volts\nA battery is at 100% at __ volts\nRange 2.8 to 3.4", type: "decimal", range: "2.8..3.4", defaultValue: 3, required: false
 		input name: "voltsmin", title: "Min Volts\nA battery is at 0% (needs replacing) at __ volts\nRange 2.0 to 2.7", type: "decimal", range: "2..2.7", defaultValue: 2.5, required: false
-		}
   }	
 }
 
+// Parse incoming device messages to generate events
 def parse(String description) {
     log.debug "${device.displayName} Parsing: $description"
 
-    //  send event for heartbeat
+	// Determine current time and date in the user-selected date format and clock style
     def now = formatDate()    
     def nowDate = new Date(now).getTime()
+	// Any report - motion, lux & Battery - results in a lastCheckin event and update to Last Checkin tile
+	// However, only a non-parseable report results in lastCheckin being displayed in events log
     sendEvent(name: "lastCheckin", value: now, displayed: false)
     sendEvent(name: "lastCheckinDate", value: nowDate, displayed: false)
 
     Map map = [:]
+	
+	// Send message data to appropriate parsing function based on the type of report	
     if (description?.startsWith('catchall:')) {
         map = parseCatchAllMessage(description)
     }
@@ -145,7 +140,6 @@ def parse(String description) {
 }
 
 private Map parseIlluminanceMessage(String description) {
-
     def Lux = ((description - "illuminance: ").trim()) as Float
 
     def result = [
@@ -158,6 +152,7 @@ private Map parseIlluminanceMessage(String description) {
     return result;
 }
 
+// Convert raw 4 digit integer voltage value into percentage based on minVolts/maxVolts range
 private Map getBatteryResult(rawValue) {
     def rawVolts = rawValue / 1000
 	def minVolts
@@ -188,6 +183,7 @@ private Map getBatteryResult(rawValue) {
     return result
 }
 
+// Check catchall for battery voltage data to pass to getBatteryResult for conversion to percentage report
 private Map parseCatchAllMessage(String description) {
     def i
     Map resultMap = [:]
@@ -346,6 +342,7 @@ def installed() {
     checkIntervalEvent("installed");
 }
 
+// updated() will run twice every time user presses save in preference settings page
 def updated() {
     checkIntervalEvent("updated");
 	if(battReset){
@@ -364,6 +361,7 @@ def formatDate(batteryReset) {
     def correctedTimezone = ""
     def timeString = clockformat ? "HH:mm:ss" : "h:mm:ss aa"
 
+	// If user's hub timezone is not set, display error messages in log and events log, and set timezone to GMT to avoid errors
     if (!(location.timeZone)) {
         correctedTimezone = TimeZone.getTimeZone("GMT")
         log.error "${device.displayName}: Time Zone not set, so GMT was used. Please set up your location in the SmartThings mobile app."

--- a/devicetypes/bspranger/xiaomi-aqara-motion-sensor.src/xiaomi-aqara-motion-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-motion-sensor.src/xiaomi-aqara-motion-sensor.groovy
@@ -184,30 +184,23 @@ private Map parseReportAttributeMessage(String description) {
 // Check catchall for battery voltage data to pass to getBatteryResult for conversion to percentage report
 private Map parseCatchAllMessage(String description) {
 	Map resultMap = [:]
-    def catchall = zigbee.parse(description)
-    def i
-    log.debug catchall
-    if (catchall.clusterId == 0x0000) {
-		def MsgLength = catchall.data.size();
-		// Xiaomi Aqara CatchAll does not have identifiers, first UINT16 is Battery
-		if ((catchall.data.get(0) == 0x02) && (catchall.data.get(1) == 0xFF)) {
-			for (i = 0; i < (MsgLength-3); i++) {
+	def catchall = zigbee.parse(description)
+	log.debug catchall
+
+	if (catchall.clusterId == 0x0000) {
+		def MsgLength = catchall.data.size()
+		// Xiaomi CatchAll does not have identifiers, first UINT16 is Battery
+		if ((catchall.data.get(0) == 0x01 || catchall.data.get(0) == 0x02) && (catchall.data.get(1) == 0xFF)) {
+			for (int i = 4; i < (MsgLength-3); i++) {
 				if (catchall.data.get(i) == 0x21) { // check the data ID and data type
 					// next two bytes are the battery voltage
 					resultMap = getBatteryResult((catchall.data.get(i+2)<<8) + catchall.data.get(i+1))
 				}
+			break
 			}
 		}
-		else if ((catchall.data.get(0) == 0x01) && (catchall.data.get(1) == 0xFF)) {
-			for (i = 0; i < (MsgLength-3); i++) {
-				if ((catchall.data.get(i) == 0x01) && (catchall.data.get(i+1) == 0x21)) { // check the data ID and data type
-					// next two bytes are the battery voltage.
-					resultMap = getBatteryResult((catchall.data.get(i+3)<<8) + catchall.data.get(i+2))
-				}
-			}
-		}
-    }
-    return resultMap
+	}
+	return resultMap
 }
 
 // Convert raw 4 digit integer voltage value into percentage based on minVolts/maxVolts range

--- a/devicetypes/bspranger/xiaomi-aqara-motion-sensor.src/xiaomi-aqara-motion-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-motion-sensor.src/xiaomi-aqara-motion-sensor.groovy
@@ -342,6 +342,7 @@ def configure() {
 
 def installed() {
     state.battery = 0
+    resetBatteryRuntime()
     checkIntervalEvent("installed");
 }
 

--- a/devicetypes/bspranger/xiaomi-button.src/xiaomi-button.groovy
+++ b/devicetypes/bspranger/xiaomi-button.src/xiaomi-button.groovy
@@ -96,9 +96,8 @@ metadata {
         details(["button","battery","lastcheckin","batteryRuntime"])
    }
    preferences {
-	section {	
-		input name: "holdTime", "number", title: "Minimum time in seconds for a press to count as \"held\"", defaultValue: 4
-        	input name: "PressType", type: "enum", options: ["Toggle", "Momentary"], description: "Effects how the button toggles", defaultValue: "Toggle"
+	section {
+        	input name: "PressType", type: "enum", options: ["Momentary", "Toggle"], title: "Momentary or toggle? ", defaultValue: "Momentary"
 		}
 	section {
 		input description: "", type: "paragraph", element: "paragraph", title: "DATE & CLOCK"    

--- a/devicetypes/bspranger/xiaomi-button.src/xiaomi-button.groovy
+++ b/devicetypes/bspranger/xiaomi-button.src/xiaomi-button.groovy
@@ -203,8 +203,8 @@ private Map parseCatchAllMessage(String description) {
 				if (catchall.data.get(i) == 0x21) { // check the data ID and data type
 					// next two bytes are the battery voltage
 					resultMap = getBatteryResult((catchall.data.get(i+2)<<8) + catchall.data.get(i+1))
+					break
 				}
-			break
 			}
 		}
 	}
@@ -215,7 +215,7 @@ private Map parseCatchAllMessage(String description) {
 private Map getBatteryResult(rawValue) {
     // raw voltage is normally supplied as a 4 digit integer that needs to be divided by 1000
     // but in the case the final zero is dropped then divide by 100 to get actual voltage value 
-    def rawVolts = (rawValue < 1000) ? (rawValue / 100) : (rawValue / 1000)
+    def rawVolts = rawValue / 1000
     def minVolts
     def maxVolts
 

--- a/devicetypes/bspranger/xiaomi-button.src/xiaomi-button.groovy
+++ b/devicetypes/bspranger/xiaomi-button.src/xiaomi-button.groovy
@@ -311,6 +311,7 @@ def configure() {
     checkIntervalEvent("configure");
 }
 
+// installed() runs just after a sensor is paired using the "Add a Thing" method in the SmartThings mobile app
 def installed() {
     state.battery = 0
     resetBatteryRuntime()

--- a/devicetypes/bspranger/xiaomi-button.src/xiaomi-button.groovy
+++ b/devicetypes/bspranger/xiaomi-button.src/xiaomi-button.groovy
@@ -316,6 +316,7 @@ def configure() {
 
 def installed() {
     state.battery = 0
+    resetBatteryRuntime()
     state.button = "released"
     checkIntervalEvent("installed");
 }

--- a/devicetypes/bspranger/xiaomi-button.src/xiaomi-button.groovy
+++ b/devicetypes/bspranger/xiaomi-button.src/xiaomi-button.groovy
@@ -301,33 +301,37 @@ private Map getContactResult(value) {
     ]
 }
 
-def resetBatteryRuntime() {
-    def now = formatDate(true)
-    sendEvent(name: "batteryRuntime", value: now)
-}
-
-def configure() {
-    log.debug "${device.displayName}: configuring"
-    state.battery = 0
-    state.button = "released"
-    checkIntervalEvent("configure");
+//Reset the date displayed in Battery Changed tile to current date
+def resetBatteryRuntime(paired) {
+	def now = formatDate(true)
+	def newlyPaired = paired ? " for newly paired sensor" : ""
+	sendEvent(name: "batteryRuntime", value: now)
+	log.debug "${device.displayName}: Setting Battery Changed to current date${newlyPaired}"
 }
 
 // installed() runs just after a sensor is paired using the "Add a Thing" method in the SmartThings mobile app
 def installed() {
-    state.battery = 0
-    resetBatteryRuntime()
-    state.button = "released"
-    checkIntervalEvent("installed");
+	state.battery = 0
+	if (!batteryRuntime) resetBatteryRuntime(true)
+	checkIntervalEvent("installed")
+}
+
+// configure() runs after installed() when a sensor is paired
+def configure() {
+	log.debug "${device.displayName}: configuring"
+		state.battery = 0
+	if (!batteryRuntime) resetBatteryRuntime(true)
+	checkIntervalEvent("configured")
+	return
 }
 
 // updated() will run twice every time user presses save in preference settings page
 def updated() {
-    checkIntervalEvent("updated");
-	if(battReset){
+		checkIntervalEvent("updated")
+		if(battReset){
 		resetBatteryRuntime()
 		device.updateSetting("battReset", false)
-	}	
+	}
 }
 
 private checkIntervalEvent(text) {

--- a/devicetypes/bspranger/xiaomi-button.src/xiaomi-button.groovy
+++ b/devicetypes/bspranger/xiaomi-button.src/xiaomi-button.groovy
@@ -220,7 +220,9 @@ private Map parseCatchAllMessage(String description) {
 
 // Convert raw 4 digit integer voltage value into percentage based on minVolts/maxVolts range
 private Map getBatteryResult(rawValue) {
-    def rawVolts = rawValue / 1000
+    // raw voltage is normally supplied as a 4 digit integer that needs to be divided by 1000
+    // but in the case the final zero is dropped then divide by 100 to get actual voltage value 
+    def rawVolts = (rawValue < 1000) ? (rawValue / 100) : (rawValue / 1000)
     def minVolts
     def maxVolts
 

--- a/devicetypes/bspranger/xiaomi-button.src/xiaomi-button.groovy
+++ b/devicetypes/bspranger/xiaomi-button.src/xiaomi-button.groovy
@@ -191,31 +191,24 @@ private Map parseReadAttrMessage(String description) {
 
 // Check catchall for battery voltage data to pass to getBatteryResult for conversion to percentage report
 private Map parseCatchAllMessage(String description) {
-    def i
-    Map resultMap = [:]
-    def cluster = zigbee.parse(description)
-    log.debug cluster
-    if (cluster) {
-        switch(cluster.clusterId) {
-            case 0x0000:
-                def MsgLength = cluster.data.size();
-                for (i = 0; i < (MsgLength-3); i++)
-                {
-                    // Original Xiaomi CatchAll does not have identifiers, first UINT16 is Battery
-                    if ((cluster.data.get(0) == 0x02) && (cluster.data.get(1) == 0xFF))
-                    {
-                        if (cluster.data.get(i) == 0x21) // check the data ID and data type
-                        {
-                            // next two bytes are the battery voltage.
-                            resultMap = getBatteryResult((cluster.data.get(i+2)<<8) + cluster.data.get(i+1))
-                            return resultMap
-                        }
-                    }
-                }
-            break
-        }
-    }
-    return resultMap
+	Map resultMap = [:]
+	def catchall = zigbee.parse(description)
+	log.debug catchall
+
+	if (catchall.clusterId == 0x0000) {
+		def MsgLength = catchall.data.size()
+		// Xiaomi CatchAll does not have identifiers, first UINT16 is Battery
+		if ((catchall.data.get(0) == 0x01 || catchall.data.get(0) == 0x02) && (catchall.data.get(1) == 0xFF)) {
+			for (int i = 4; i < (MsgLength-3); i++) {
+				if (catchall.data.get(i) == 0x21) { // check the data ID and data type
+					// next two bytes are the battery voltage
+					resultMap = getBatteryResult((catchall.data.get(i+2)<<8) + catchall.data.get(i+1))
+				}
+			break
+			}
+		}
+	}
+	return resultMap
 }
 
 // Convert raw 4 digit integer voltage value into percentage based on minVolts/maxVolts range

--- a/devicetypes/bspranger/xiaomi-button.src/xiaomi-button.groovy
+++ b/devicetypes/bspranger/xiaomi-button.src/xiaomi-button.groovy
@@ -1,5 +1,7 @@
 /**
  *  Xiaomi Zigbee Button
+ *  Version 1.0
+ *
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  *  in compliance with the License. You may obtain a copy of the License at:
@@ -9,20 +11,14 @@
  *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
  *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
  *  for the specific language governing permissions and limitations under the License.
+ *
+ *  Original device handler code by a4refillpad, adapted for use with Aqara model by bspranger
+ *  Additional contributions to code by alecm, alixjg, bspranger, gn0st1c, foz333, jmagnuson, rinkek, ronvandegraaf, snalee, tmleafs, twonk, & veeceeoh 
  * 
-  * Based on original DH by Eric Maycock 2015 and Rave from Lazcad
- *  change log:
- *  25.01.2018 added virtualApp button on tile
- *  added 100% battery max
- *  fixed battery parsing problem
- *  added lastcheckin attribute and tile
- *  added a means to also push button in as tile on smartthings app
- *  fixed ios tile label problem and battery bug 
- *  sulee: change battery calculation
- *  sulee: changed to work as a push button
- *  sulee: added endpoint for Smartthings to detect properly
- *  sulee: cleaned everything up
- *  bspranger: renamed to bspranger to remove confusion of a4refillpad
+ *  Known issues:
+ *  Xiaomi sensors do not seem to respond to refresh requests
+ *  Inconsistent rendering of user interface text/graphics between iOS and Android devices - This is due to SmartThings, not this device handler
+ *  Pairing Xiaomi sensors can be difficult as they were not designed to use with a SmartThings hub. See 
  *
  *  Fingerprint Endpoint data:
  *  zbjoin: {"dni":"xxxx","d":"xxxxxxxxxxx","capabilities":"80","endpoints":[{"simple":"01 0104 5F01 01 03 0000 FFFF 0006 03 0000 0004 FFFF","application":"03","manufacturer":"LUMI","model":"lumi.sensor_switch.aq2"}],"parent":"0000","joinType":1}
@@ -96,24 +92,20 @@ metadata {
         details(["button","battery","lastcheckin","batteryRuntime"])
    }
    preferences {
-	section {
+		//Button Config
         	input name: "PressType", type: "enum", options: ["Momentary", "Toggle"], title: "Momentary or toggle? ", defaultValue: "Momentary"
-		}
-	section {
+		//Date & Time Config
 		input description: "", type: "paragraph", element: "paragraph", title: "DATE & CLOCK"    
 		input name: "dateformat", type: "enum", title: "Set Date Format\n US (MDY) - UK (DMY) - Other (YMD)", description: "Date Format", options:["US","UK","Other"]
-		input name: "clockformat", type: "bool", title: "Use 24 hour clock?", defaultValue: false
-		}
-	section {
+		input name: "clockformat", type: "bool", title: "Use 24 hour clock?"
+		//Battery Reset Config
             	input description: "If you have installed a new battery, the toggle below will reset the Changed Battery date to help remember when it was changed.", type: "paragraph", element: "paragraph", title: "CHANGED BATTERY DATE RESET"
-		input name: "battReset", type: "bool", title: "Battery Changed?", description: ""
-		}
-	section {
+		input name: "battReset", type: "bool", title: "Battery Changed?"
+		//Battery Voltage Offset
             	input description: "Only change the settings below if you know what you're doing.", type: "paragraph", element: "paragraph", title: "ADVANCED SETTINGS"
 		input name: "voltsmax", title: "Max Volts\nA battery is at 100% at __ volts\nRange 2.8 to 3.4", type: "decimal", range: "2.8..3.4", defaultValue: 3, required: false
 		input name: "voltsmin", title: "Min Volts\nA battery is at 0% (needs replacing) at __ volts\nRange 2.0 to 2.7", type: "decimal", range: "2..2.7", defaultValue: 2.5, required: false
-		}
-     }
+    }
 }
 
 //adds functionality to press the centre tile as a virtualApp Button
@@ -127,17 +119,21 @@ def push() {
 	sendEvent(name: "button", value: "released", data: [buttonNumber: 1], descriptionText: "$device.displayName app button was released", isStateChange: true)
 }
 
+// Parse incoming device messages to generate events
 def parse(String description) {
     log.debug "${device.displayName}: Parsing '${description}'"
 
-    //  send event for heartbeat    
+	// Determine current time and date in the user-selected date format and clock style 
     def now = formatDate()	
     def nowDate = new Date(now).getTime()
+	// Any report - button press & Battery - results in a lastCheckin event and update to Last Checkin tile
+	// However, only a non-parseable report results in lastCheckin being displayed in events log
     sendEvent(name: "lastCheckin", value: now, displayed: false)
     sendEvent(name: "lastCheckinDate", value: nowDate, displayed: false) 
 
     Map map = [:]
 
+	// Send message data to appropriate parsing function based on the type of report
     if (description?.startsWith('on/off: ')) 
     {
         map = parseCustomMessage(description) 
@@ -193,6 +189,7 @@ private Map parseReadAttrMessage(String description) {
     return [:]    
 }
 
+// Check catchall for battery voltage data to pass to getBatteryResult for conversion to percentage report
 private Map parseCatchAllMessage(String description) {
     def i
     Map resultMap = [:]
@@ -221,6 +218,7 @@ private Map parseCatchAllMessage(String description) {
     return resultMap
 }
 
+// Convert raw 4 digit integer voltage value into percentage based on minVolts/maxVolts range
 private Map getBatteryResult(rawValue) {
     def rawVolts = rawValue / 1000
     def minVolts
@@ -320,6 +318,7 @@ def installed() {
     checkIntervalEvent("installed");
 }
 
+// updated() will run twice every time user presses save in preference settings page
 def updated() {
     checkIntervalEvent("updated");
 	if(battReset){
@@ -338,6 +337,7 @@ def formatDate(batteryReset) {
     def correctedTimezone = ""
     def timeString = clockformat ? "HH:mm:ss" : "h:mm:ss aa"
 
+	// If user's hub timezone is not set, display error messages in log and events log, and set timezone to GMT to avoid errors
     if (!(location.timeZone)) {
         correctedTimezone = TimeZone.getTimeZone("GMT")
         log.error "${device.displayName}: Time Zone not set, so GMT was used. Please set up your location in the SmartThings mobile app."

--- a/devicetypes/bspranger/xiaomi-door-window-sensor.src/xiaomi-door-window-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-door-window-sensor.src/xiaomi-door-window-sensor.groovy
@@ -273,6 +273,7 @@ def configure() {
 
 def installed() {
     state.battery = 0
+    resetBatteryRuntime()
     checkIntervalEvent("installed");
 }
 

--- a/devicetypes/bspranger/xiaomi-door-window-sensor.src/xiaomi-door-window-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-door-window-sensor.src/xiaomi-door-window-sensor.groovy
@@ -156,7 +156,7 @@ private Map parseReadAttrMessage(String description) {
 private Map getBatteryResult(rawValue) {
     // raw voltage is normally supplied as a 4 digit integer that needs to be divided by 1000
     // but in the case the final zero is dropped then divide by 100 to get actual voltage value 
-    def rawVolts = (rawValue < 1000) ? (rawValue / 100) : (rawValue / 1000)
+    def rawVolts = rawValue / 1000
     def minVolts
     def maxVolts
 
@@ -199,8 +199,8 @@ private Map parseCatchAllMessage(String description) {
 				if (catchall.data.get(i) == 0x21) { // check the data ID and data type
 					// next two bytes are the battery voltage
 					resultMap = getBatteryResult((catchall.data.get(i+2)<<8) + catchall.data.get(i+1))
+					break
 				}
-			break
 			}
 		}
 	}

--- a/devicetypes/bspranger/xiaomi-door-window-sensor.src/xiaomi-door-window-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-door-window-sensor.src/xiaomi-door-window-sensor.groovy
@@ -1,5 +1,6 @@
 /**
  *  Xiaomi Door/Window Sensor
+ *  Version 1.0
  *
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -11,22 +12,15 @@
  *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
  *  for the specific language governing permissions and limitations under the License.
  *
- * Based on original DH by Eric Maycock 2015 and Rave from Lazcad
- *  change log:
- *    added DH Colours
- *  added 100% battery max
- *  fixed battery parsing problem
- *  added lastcheckin attribute and tile
- *  added extra tile to show when last opened
- *  colours to confirm to new smartthings standards
- *  added ability to force override current state to Open or Closed.
- *  added experimental health check as worked out by rolled54.Why
- *  Rinkelk - added date-attribute support for Webcore
- *  Rinkelk - Changed battery icon according to Mobile785
- *  bspranger - renamed to bspranger to remove confusion of a4refillpad
+ *  Original device handler code by a4refillpad, adapted for use with Aqara model by bspranger
+ *  Additional contributions to code by alecm, alixjg, bspranger, gn0st1c, foz333, jmagnuson, rinkek, ronvandegraaf, snalee, tmleafs, twonk, & veeceeoh 
+ * 
+ *  Known issues:
+ *  Xiaomi sensors do not seem to respond to refresh requests
+ *  Inconsistent rendering of user interface text/graphics between iOS and Android devices - This is due to SmartThings, not this device handler
+ *  Pairing Xiaomi sensors can be difficult as they were not designed to use with a SmartThings hub.
  *
  */
-
 metadata {
    definition (name: "Xiaomi Door/Window Sensor", namespace: "bspranger", author: "bspranger") {
    capability "Configuration"
@@ -90,34 +84,35 @@ metadata {
 	details(["contact","battery","resetClosed","resetOpen","spacer","lastcheckin", "spacer", "spacer", "batteryRuntime", "spacer"])
    }
    preferences {
-	section {
+		//Date & Time Config
 		input description: "", type: "paragraph", element: "paragraph", title: "DATE & CLOCK"    
 		input name: "dateformat", type: "enum", title: "Set Date Format\n US (MDY) - UK (DMY) - Other (YMD)", description: "Date Format", options:["US","UK","Other"]
-		input name: "clockformat", type: "bool", title: "Use 24 hour clock?", defaultValue: false
-		}
-	section {
+		input name: "clockformat", type: "bool", title: "Use 24 hour clock?"
+		//Battery Reset Config
             	input description: "If you have installed a new battery, the toggle below will reset the Changed Battery date to help remember when it was changed.", type: "paragraph", element: "paragraph", title: "CHANGED BATTERY DATE RESET"
-		input name: "battReset", type: "bool", title: "Battery Changed?", description: ""
-		}
-	section {
+		input name: "battReset", type: "bool", title: "Battery Changed?"
+		//Battery Voltage Offset
 	        input description: "Only change the settings below if you know what you're doing.", type: "paragraph", element: "paragraph", title: "ADVANCED SETTINGS"
 		input name: "voltsmax", title: "Max Volts\nA battery is at 100% at __ volts\nRange 2.8 to 3.4", type: "decimal", range: "2.8..3.4", defaultValue: 3, required: false
 		input name: "voltsmin", title: "Min Volts\nA battery is at 0% (needs replacing) at __ volts\nRange 2.0 to 2.7", type: "decimal", range: "2..2.7", defaultValue: 2.5, required: false
-		}
     } 
 }
 
+// Parse incoming device messages to generate events
 def parse(String description) {
     log.debug "${device.displayName}: Parsing '${description}'"
 
-    //  send event for heartbeat    
+	// Determine current time and date in the user-selected date format and clock style
     def now = formatDate()
     def nowDate = new Date(now).getTime()
+	// Any report - button press & Battery - results in a lastCheckin event and update to Last Checkin tile
+	// However, only a non-parseable report results in lastCheckin being displayed in events log
     sendEvent(name: "lastCheckin", value: now, displayed: false)
     sendEvent(name: "lastCheckinDate", value: nowDate, displayed: false) 
 
     Map map = [:]
 
+	// Send message data to appropriate parsing function based on the type of report
     if (description?.startsWith('on/off: ')) 
     {
         map = parseCustomMessage(description) 
@@ -166,6 +161,7 @@ private Map parseReadAttrMessage(String description) {
     return result
 }
 
+// Convert raw 4 digit integer voltage value into percentage based on minVolts/maxVolts range
 private Map getBatteryResult(rawValue) {
     def rawVolts = rawValue / 1000
 	 def minVolts
@@ -196,6 +192,7 @@ private Map getBatteryResult(rawValue) {
     return result
 }
 
+// Check catchall for battery voltage data to pass to getBatteryResult for conversion to percentage report
 private Map parseCatchAllMessage(String description) {
     Map resultMap = [:]
     def cluster = zigbee.parse(description)
@@ -224,9 +221,6 @@ private Map parseCatchAllMessage(String description) {
 
     return resultMap
 }
-
-
-
 
 private Map parseCustomMessage(String description) {
     def result
@@ -277,6 +271,7 @@ def installed() {
     checkIntervalEvent("installed");
 }
 
+// updated() will run twice every time user presses save in preference settings page
 def updated() {
     checkIntervalEvent("updated");
 	if(battReset){
@@ -295,6 +290,7 @@ def formatDate(batteryReset) {
     def correctedTimezone = ""
     def timeString = clockformat ? "HH:mm:ss" : "h:mm:ss aa"
 
+	// If user's hub timezone is not set, display error messages in log and events log, and set timezone to GMT to avoid errors
     if (!(location.timeZone)) {
         correctedTimezone = TimeZone.getTimeZone("GMT")
         log.error "${device.displayName}: Time Zone not set, so GMT was used. Please set up your location in the SmartThings mobile app."

--- a/devicetypes/bspranger/xiaomi-door-window-sensor.src/xiaomi-door-window-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-door-window-sensor.src/xiaomi-door-window-sensor.groovy
@@ -265,6 +265,7 @@ def configure() {
     checkIntervalEvent("configure");
 }
 
+// installed() runs just after a sensor is paired using the "Add a Thing" method in the SmartThings mobile app
 def installed() {
     state.battery = 0
     resetBatteryRuntime()

--- a/devicetypes/bspranger/xiaomi-door-window-sensor.src/xiaomi-door-window-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-door-window-sensor.src/xiaomi-door-window-sensor.groovy
@@ -163,8 +163,10 @@ private Map parseReadAttrMessage(String description) {
 
 // Convert raw 4 digit integer voltage value into percentage based on minVolts/maxVolts range
 private Map getBatteryResult(rawValue) {
-    def rawVolts = rawValue / 1000
-	 def minVolts
+    // raw voltage is normally supplied as a 4 digit integer that needs to be divided by 1000
+    // but in the case the final zero is dropped then divide by 100 to get actual voltage value 
+    def rawVolts = (rawValue < 1000) ? (rawValue / 100) : (rawValue / 1000)
+    def minVolts
     def maxVolts
 
     if(voltsmin == null || voltsmin == "")

--- a/devicetypes/bspranger/xiaomi-motion-sensor.src/xiaomi-motion-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-motion-sensor.src/xiaomi-motion-sensor.groovy
@@ -63,8 +63,11 @@ metadata {
                 [value: 51, color: "#44b621"]
             ]
         }
-        standardTile("empty2x2", "null", width: 2, height: 2, decoration: "flat") {
-             state "emptySmall", label:'', defaultState: true
+       valueTile("spacer1", "spacer1", decoration: "flat", inactiveLabel: false, width: 1, height: 1) {
+	    state "default", label:''
+        }
+        valueTile("spacer2", "spacer2", decoration: "flat", inactiveLabel: false, width: 1, height: 2) {
+	    state "default", label:''
         }
         standardTile("reset", "device.reset", inactiveLabel: false, decoration: "flat", width: 2, height: 2) {
             state "default", action:"reset", label: "Reset Motion", icon:"st.motion.motion.active"
@@ -76,7 +79,7 @@ metadata {
              state "batteryRuntime", label:'Battery Changed:\n ${currentValue}'
         }
         main(["motion"])
-        details(["motion", "battery", "empty2x2", "reset", "lastcheckin", "batteryRuntime"])
+        details(["motion", "spacer2", "battery", "reset", "spacer2", "spacer2", "lastcheckin", "spacer2", "spacer2", "batteryRuntime", "spacer2"])
    }
    preferences {
 		//motion Time out

--- a/devicetypes/bspranger/xiaomi-motion-sensor.src/xiaomi-motion-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-motion-sensor.src/xiaomi-motion-sensor.groovy
@@ -125,7 +125,9 @@ def parse(String description) {
 
 // Convert raw 4 digit integer voltage value into percentage based on minVolts/maxVolts range
 private Map getBatteryResult(rawValue) {
-    def rawVolts = rawValue / 1000
+    // raw voltage is normally supplied as a 4 digit integer that needs to be divided by 1000
+    // but in the case the final zero is dropped then divide by 100 to get actual voltage value 
+    def rawVolts = (rawValue < 1000) ? (rawValue / 100) : (rawValue / 1000)
     def minVolts
     def maxVolts
 

--- a/devicetypes/bspranger/xiaomi-motion-sensor.src/xiaomi-motion-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-motion-sensor.src/xiaomi-motion-sensor.groovy
@@ -1,5 +1,6 @@
 /**
  *  Xiaomi Motion Sensor
+ *  Version 1.0
  *
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -11,19 +12,13 @@
  *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
  *  for the specific language governing permissions and limitations under the License.
  *
- * Based on original DH by Eric Maycock 2015
- * modified 29/12/2016 a4refillpad 
- * Added fingerprinting
- * Added heartbeat/lastcheckin for monitoring
- * Added battery and refresh 
- * Motion background colours consistent with latest DH
- * Fixed max battery percentage to be 100%
- * Added Last update to main tile
- * Added last motion tile
- * Heartdeat icon plus improved localisation of date
- * removed non working tiles and changed layout and incorporated latest colours
- * added experimental health check as worked out by rolled54.Why
- *  bspranger - renamed to bspranger to remove confusion of a4refillpad
+ *  Original device handler code by a4refillpad, adapted for use with Aqara model by bspranger
+ *  Additional contributions to code by alecm, alixjg, bspranger, gn0st1c, foz333, jmagnuson, rinkek, ronvandegraaf, snalee, tmleafs, twonk, & veeceeoh 
+ * 
+ *  Known issues:
+ *  Xiaomi sensors do not seem to respond to refresh requests
+ *  Inconsistent rendering of user interface text/graphics between iOS and Android devices - This is due to SmartThings, not this device handler
+ *  Pairing Xiaomi sensors can be difficult as they were not designed to use with a SmartThings hub. See 
  *
  */
 
@@ -84,36 +79,37 @@ metadata {
         details(["motion", "battery", "empty2x2", "reset", "lastcheckin", "batteryRuntime"])
    }
    preferences {
-	section {
-	        input name: "motionReset", "number", title: "Number of seconds after the last reported activity to report that motion is inactive (in seconds). \n\n(The device will always remain blind to motion for 60seconds following first detected motion. This value just clears the 'active' status after the number of seconds you set here but the device will still remain blind for 60seconds in normal operation.)", description: "", value:120, displayDuringSetup: true
-		}	 
-	section {
+		//motion Time out
+	        input name: "motionReset", "number", title: "Number of seconds after the last reported activity to report that motion is inactive (in seconds). \n\n(The device will always remain blind to motion for 60seconds following first detected motion. This value just clears the 'active' status after the number of seconds you set here but the device will still remain blind for 60seconds in normal operation.)", description: "", defaultValue:120
+		//Date & Time Config
 		input description: "", type: "paragraph", element: "paragraph", title: "DATE & CLOCK"    
 		input name: "dateformat", type: "enum", title: "Set Date Format\n US (MDY) - UK (DMY) - Other (YMD)", description: "Date Format", options:["US","UK","Other"]
-		input name: "clockformat", type: "bool", title: "Use 24 hour clock?", defaultValue: false
-		}
-	section {
+		input name: "clockformat", type: "bool", title: "Use 24 hour clock?"
+		//Battery Reset Config
             	input description: "If you have installed a new battery, the toggle below will reset the Changed Battery date to help remember when it was changed.", type: "paragraph", element: "paragraph", title: "CHANGED BATTERY DATE RESET"
-		input name: "battReset", type: "bool", title: "Battery Changed?", description: ""
-		}
-	section {
+		input name: "battReset", type: "bool", title: "Battery Changed?"
+		//Battery Voltage Offset
 	        input description: "Only change the settings below if you know what you're doing.", type: "paragraph", element: "paragraph", title: "ADVANCED SETTINGS"
 		input name: "voltsmax", title: "Max Volts\nA battery is at 100% at __ volts\nRange 2.8 to 3.4", type: "decimal", range: "2.8..3.4", defaultValue: 3, required: false
 		input name: "voltsmin", title: "Min Volts\nA battery is at 0% (needs replacing) at __ volts\nRange 2.0 to 2.7", type: "decimal", range: "2..2.7", defaultValue: 2.5, required: false
-		}
   }
 }
 
+// Parse incoming device messages to generate events
 def parse(String description) {
     log.debug "${device.displayName} Parsing: $description"
 	
-	//  send event for heartbeat
+	// Determine current time and date in the user-selected date format and clock style
 	def now = formatDate()    
 	def nowDate = new Date(now).getTime()
+	// Any report - motion, lux & Battery - results in a lastCheckin event and update to Last Checkin tile
+	// However, only a non-parseable report results in lastCheckin being displayed in events log
 	sendEvent(name: "lastCheckin", value: now, displayed: false)
 	sendEvent(name: "lastCheckinDate", value: nowDate, displayed: false)
 	
 	Map map = [:]
+
+	// Send message data to appropriate parsing function based on the type of report	
 	if (description?.startsWith('catchall:')) {
 		map = parseCatchAllMessage(description)
 	}
@@ -127,6 +123,7 @@ def parse(String description) {
 	return result
 }
 
+// Convert raw 4 digit integer voltage value into percentage based on minVolts/maxVolts range
 private Map getBatteryResult(rawValue) {
     def rawVolts = rawValue / 1000
     def minVolts
@@ -157,6 +154,7 @@ private Map getBatteryResult(rawValue) {
     return result
 }
 
+// Check catchall for battery voltage data to pass to getBatteryResult for conversion to percentage report
 private Map parseCatchAllMessage(String description) {
 	Map resultMap = [:]
 	def cluster = zigbee.parse(description)
@@ -213,13 +211,7 @@ private Map parseReportAttributeMessage(String description) {
 	//log.debug "Desc Map: $descMap"
  
 	Map resultMap = [:]
-	def now
-	if(dateformat == "US" || dateformat == "" || dateformat == null)
-        now = new Date().format("EEE MMM dd yyyy h:mm:ss a", location.timeZone)
-	else if(dateformat == "UK")
-	now = new Date().format("EEE dd MMM yyyy h:mm:ss a", location.timeZone)
-	else
-	now = new Date().format("EEE yyyy MMM dd h:mm:ss a", location.timeZone)
+        def now = new Date().format("EEE MMM dd yyyy h:mm:ss a", location.timeZone)
    
 	if (descMap.cluster == "0001" && descMap.attrId == "0020") {
 		resultMap = getBatteryResult(Integer.parseInt(descMap.value, 16))
@@ -325,6 +317,7 @@ def installed() {
     checkIntervalEvent("installed");
 }
 
+// updated() will run twice every time user presses save in preference settings page
 def updated() {
     checkIntervalEvent("updated");
 	if(battReset){
@@ -343,6 +336,7 @@ def formatDate(batteryReset) {
     def correctedTimezone = ""
     def timeString = clockformat ? "HH:mm:ss" : "h:mm:ss aa"
 
+	// If user's hub timezone is not set, display error messages in log and events log, and set timezone to GMT to avoid errors
     if (!(location.timeZone)) {
         correctedTimezone = TimeZone.getTimeZone("GMT")
         log.error "${device.displayName}: Time Zone not set, so GMT was used. Please set up your location in the SmartThings mobile app."

--- a/devicetypes/bspranger/xiaomi-motion-sensor.src/xiaomi-motion-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-motion-sensor.src/xiaomi-motion-sensor.groovy
@@ -177,8 +177,8 @@ private Map parseCatchAllMessage(String description) {
 				if (catchall.data.get(i) == 0x21) { // check the data ID and data type
 					// next two bytes are the battery voltage
 					resultMap = getBatteryResult((catchall.data.get(i+2)<<8) + catchall.data.get(i+1))
+					break
 				}
-			break
 			}
 		}
 	}
@@ -189,7 +189,7 @@ private Map parseCatchAllMessage(String description) {
 private Map getBatteryResult(rawValue) {
     // raw voltage is normally supplied as a 4 digit integer that needs to be divided by 1000
     // but in the case the final zero is dropped then divide by 100 to get actual voltage value 
-    def rawVolts = (rawValue < 1000) ? (rawValue / 100) : (rawValue / 1000)
+    def rawVolts = rawValue / 1000
     def minVolts
     def maxVolts
 
@@ -222,7 +222,7 @@ def stopMotion() {
 	if (device.currentState('motion')?.value == "active") {
 		def seconds = motionreset ? motionreset : 60
 		sendEvent(name:"motion", value:"inactive", isStateChange: true)
-		log.debug "${device.displayName} reset to no motion after ${seconds}"
+		log.debug "${device.displayName} reset to no motion after ${seconds} seconds"
 	}
 }
 

--- a/devicetypes/bspranger/xiaomi-motion-sensor.src/xiaomi-motion-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-motion-sensor.src/xiaomi-motion-sensor.groovy
@@ -167,17 +167,18 @@ private Map parseReportAttributeMessage(String description) {
 private Map parseCatchAllMessage(String description) {
 	Map resultMap = [:]
 	def catchall = zigbee.parse(description)
-    def i
 	log.debug catchall
-	if  (catchall.clusterId == 0x0000) {
-		def MsgLength = catchall.data.size();
-		// Xiaomi Aqara CatchAll does not have identifiers, first UINT16 is Battery
-		if ((catchall.data.get(0) == 0x02) && (catchall.data.get(1) == 0xFF)) {
-			for (i = 0; i < (MsgLength-3); i++) {
+
+	if (catchall.clusterId == 0x0000) {
+		def MsgLength = catchall.data.size()
+		// Xiaomi CatchAll does not have identifiers, first UINT16 is Battery
+		if ((catchall.data.get(0) == 0x01 || catchall.data.get(0) == 0x02) && (catchall.data.get(1) == 0xFF)) {
+			for (int i = 4; i < (MsgLength-3); i++) {
 				if (catchall.data.get(i) == 0x21) { // check the data ID and data type
 					// next two bytes are the battery voltage
 					resultMap = getBatteryResult((catchall.data.get(i+2)<<8) + catchall.data.get(i+1))
 				}
+			break
 			}
 		}
 	}

--- a/devicetypes/bspranger/xiaomi-motion-sensor.src/xiaomi-motion-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-motion-sensor.src/xiaomi-motion-sensor.groovy
@@ -79,7 +79,7 @@ metadata {
              state "batteryRuntime", label:'Battery Changed:\n ${currentValue}'
         }
         main(["motion"])
-        details(["motion", "spacer2", "battery", "reset", "spacer2", "spacer2", "lastcheckin", "spacer2", "spacer2", "batteryRuntime", "spacer2"])
+        details(["motion", "spacer2", "battery", "reset", "spacer2", "spacer1", "lastcheckin", "spacer1", "spacer1", "batteryRuntime", "spacer1"])
    }
 
    preferences {

--- a/devicetypes/bspranger/xiaomi-motion-sensor.src/xiaomi-motion-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-motion-sensor.src/xiaomi-motion-sensor.groovy
@@ -321,6 +321,7 @@ def configure() {
 
 def installed() {
     state.battery = 0
+    resetBatteryRuntime()
     checkIntervalEvent("installed");
 }
 

--- a/devicetypes/bspranger/xiaomi-temperature-humidity-sensor.src/xiaomi-temperature-humidity-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-temperature-humidity-sensor.src/xiaomi-temperature-humidity-sensor.groovy
@@ -117,8 +117,7 @@ metadata {
                 [value: 59, color: "#0072BB"],
                 [value: 76, color: "#085396"]
             ]
-        }
-        
+        }        
         valueTile("battery", "device.battery", inactiveLabel: false, width: 2, height: 2) {
             state "battery", label:'${currentValue}%', unit:"%",
             backgroundColors:[
@@ -127,6 +126,12 @@ metadata {
                 [value: 51, color: "#44b621"]
             ]
         }
+        valueTile("spacer1", "spacer1", decoration: "flat", inactiveLabel: false, width: 1, height: 1) {
+	    state "default", label:''
+        }
+        valueTile("spacer2", "spacer2", decoration: "flat", inactiveLabel: false, width: 1, height: 2) {
+	    state "default", label:''
+        }
         valueTile("lastcheckin", "device.lastCheckin", inactiveLabel: false, decoration:"flat", width: 4, height: 1) {
             state "lastcheckin", label:'Last Event:\n ${currentValue}'
         }     
@@ -134,7 +139,7 @@ metadata {
             state "batteryRuntime", label:'Battery Changed: ${currentValue}'
         }     
         main("temperature2")
-        details(["temperature", "battery", "humidity", "lastcheckin", "batteryRuntime"])
+        details(["temperature", "spacer2", "battery", "humidity", "spacer2", "spacer1", "lastcheckin",  "spacer1", "spacer1", "batteryRuntime", "spacer1"])
     }
     preferences {
 		//Button Config

--- a/devicetypes/bspranger/xiaomi-temperature-humidity-sensor.src/xiaomi-temperature-humidity-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-temperature-humidity-sensor.src/xiaomi-temperature-humidity-sensor.groovy
@@ -144,12 +144,12 @@ metadata {
     preferences {
 		//Button Config
 		input description: "The settings below customize additional infomation displayed in the main status tile.", type: "paragraph", element: "paragraph", title: "MAIN TILE DISPLAY"
-		input name: "displayTempInteger", type: "bool", title: "Display temperature as integer?"
+		input name: "displayTempInteger", type: "bool", title: "Display temperature as integer?", description:"NOTE: Takes effect on the next temperature report. High/Low temperatures are always displayed as integers."
 		input name: "displayTempHighLow", type: "bool", title: "Display high/low temperature?"
 		input name: "displayHumidHighLow", type: "bool", title: "Display high/low humidity?"
 		//Temp and Humidity Offsets
 		input description: "The settings below allow correction of variations in temperature and humidity by setting an offset. Examples: If the sensor consistently reports temperature 5 degrees too warm, enter '-5' for the Temperature Offset. If it reports humidity 3% too low, enter ‘3' for the Humidity Offset. NOTE: Changes will take effect on the NEXT temperature / humidity / pressure report.", type: "paragraph", element: "paragraph", title: "OFFSETS & UNITS"
-		input "tempOffset", "number", title:"Temperature Offset", description:"Adjust temperature by this many degrees", range:"*..*"
+		input "tempOffset", "decimal", title:"Temperature Offset", description:"Adjust temperature by this many degrees", range:"*..*"
 		input "humidOffset", "number", title:"Humidity Offset", description:"Adjust humidity by this many percent", range: "*..*"
 		input description: "NOTE: The temperature unit (C / F) can be changed in the location settings for your hub.", type: "paragraph", element: "paragraph", title: ""
 		//Date & Time Config

--- a/devicetypes/bspranger/xiaomi-temperature-humidity-sensor.src/xiaomi-temperature-humidity-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-temperature-humidity-sensor.src/xiaomi-temperature-humidity-sensor.groovy
@@ -236,8 +236,8 @@ private Map parseCatchAllMessage(String description) {
 				if (catchall.data.get(i) == 0x21) { // check the data ID and data type
 					// next two bytes are the battery voltage
 					resultMap = getBatteryResult((catchall.data.get(i+2)<<8) + catchall.data.get(i+1))
+					break
 				}
-			break
 			}
 		}
 	}
@@ -269,7 +269,7 @@ private Map parseReadAttr(String description) {
 private Map getBatteryResult(rawValue) {
     // raw voltage is normally supplied as a 4 digit integer that needs to be divided by 1000
     // but in the case the final zero is dropped then divide by 100 to get actual voltage value 
-    def rawVolts = (rawValue < 1000) ? (rawValue / 100) : (rawValue / 1000)
+    def rawVolts = rawValue / 1000
     def minVolts
     def maxVolts
 

--- a/devicetypes/bspranger/xiaomi-temperature-humidity-sensor.src/xiaomi-temperature-humidity-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-temperature-humidity-sensor.src/xiaomi-temperature-humidity-sensor.groovy
@@ -24,22 +24,25 @@
 
 metadata {
     definition (name: "Xiaomi Temperature Humidity Sensor", namespace: "bspranger", author: "bspranger") {
-        capability "Temperature Measurement"
-        capability "Relative Humidity Measurement"
-        capability "Sensor"
-        capability "Battery"
-        capability "Health Check"
-        
-        attribute "lastCheckin", "String"
-	attribute "lastCheckinDate", "String"
-        attribute "maxTemp", "number"
-	attribute "minTemp", "number"
-        attribute "batteryRuntime", "String"
-        
-        fingerprint profileId: "0104", deviceId: "0302", inClusters: "0000,0001,0003,0009,0402,0405"
+	capability "Temperature Measurement"
+	capability "Relative Humidity Measurement"
+	capability "Sensor"
+	capability "Battery"
+	capability "Health Check"
 
-        command "resetBatteryRuntime"
-	command "tempReset"
+	attribute "lastCheckin", "String"
+	attribute "lastCheckinDate", "String"
+	attribute "maxTemp", "number"
+	attribute "minTemp", "number"
+	attribute "maxHumidity", "number"
+	attribute "minHumidity", "number"
+	attribute "multiAttributesReport", "String"
+	attribute "currentDay", "String"
+	attribute "batteryRuntime", "String"
+    
+	fingerprint profileId: "0104", deviceId: "0302", inClusters: "0000,0001,0003,0009,0402,0405"
+
+	command "resetBatteryRuntime"
 }
 
     // simulator metadata
@@ -57,7 +60,35 @@ metadata {
         multiAttributeTile(name:"temperature", type:"generic", width:6, height:4) {
             tileAttribute("device.temperature", key:"PRIMARY_CONTROL"){
                 attributeState("temperature", label:'${currentValue}°',
+					backgroundColors:[
+                        // Fahrenheit color set
+                        [value: 0, color: "#153591"],
+                        [value: 5, color: "#1e9cbb"],
+                        [value: 10, color: "#90d2a7"],
+                        [value: 15, color: "#44b621"],
+                        [value: 20, color: "#f1d801"],
+                        [value: 25, color: "#d04e00"],
+                        [value: 30, color: "#bc2323"],
+                        [value: 44, color: "#1e9cbb"],
+                        [value: 59, color: "#90d2a7"],
+                        [value: 74, color: "#44b621"],
+                        [value: 84, color: "#f1d801"],
+                        [value: 95, color: "#d04e00"],
+                        [value: 96, color: "#bc2323"]
+                        // Celsius color set (to switch, delete the 13 lines above anmd remove the two slashes at the beginning of the line below)
+                        //[value: 0, color: "#153591"], [value: 7, color: "#1e9cbb"], [value: 15, color: "#90d2a7"], [value: 23, color: "#44b621"], [value: 28, color: "#f1d801"], [value: 35, color: "#d04e00"], [value: 37, color: "#bc2323"]
+					]
+                )
+            }
+            tileAttribute("device.multiAttributesReport", key: "SECONDARY_CONTROL") {
+                attributeState("multiAttributesReport", label:'${currentValue}' //icon:"st.Weather.weather12",
+                )
+            }
+        }
+        valueTile("temperature2", "device.temperature", inactiveLabel: false) {
+            state "temperature", label:'${currentValue}°', icon: "st.Weather.weather2",
                 backgroundColors:[
+                    // Fahrenheit color set
                     [value: 0, color: "#153591"],
                     [value: 5, color: "#1e9cbb"],
                     [value: 10, color: "#90d2a7"],
@@ -70,16 +101,13 @@ metadata {
                     [value: 74, color: "#44b621"],
                     [value: 84, color: "#f1d801"],
                     [value: 95, color: "#d04e00"],
-                    [value: 96, color: "#bc2323"]                                      
+                    [value: 96, color: "#bc2323"]
+                    // Celsius color set (to switch, delete the 13 lines above anmd remove the two slashes at the beginning of the line below)
+                    //[value: 0, color: "#153591"], [value: 7, color: "#1e9cbb"], [value: 15, color: "#90d2a7"], [value: 23, color: "#44b621"], [value: 28, color: "#f1d801"], [value: 35, color: "#d04e00"], [value: 37, color: "#bc2323"]
                 ]
-            )
-            }
-            tileAttribute("device.lastCheckin", key: "SECONDARY_CONTROL") {
-                attributeState("default", label:'Last Event: ${currentValue}', icon: "st.Health & Wellness.health9")
-            }
         }
-        valueTile("humidity", "device.humidity", inactiveLabel: false, decoration: "flat", width: 2, height: 2) {
-            state "default", label:'${currentValue}%', icon:"st.Weather.weather12",
+        valueTile("humidity", "device.humidity", inactiveLabel: false, width: 2, height: 2) {
+            state "default", label:'${currentValue}%', unit:"%", icon:"st.Weather.weather12",
             backgroundColors:[
                 [value: 0, color: "#FFFCDF"],
                 [value: 4, color: "#FDF789"],
@@ -91,164 +119,102 @@ metadata {
             ]
         }
         
-        valueTile("battery", "device.battery", decoration: "flat", inactiveLabel: false, width: 2, height: 2) {
-            state "default", label:'${currentValue}%', unit:"",
+        valueTile("battery", "device.battery", inactiveLabel: false, width: 2, height: 2) {
+            state "battery", label:'${currentValue}%', unit:"%",
             backgroundColors:[
                 [value: 10, color: "#bc2323"],
                 [value: 26, color: "#f1d801"],
                 [value: 51, color: "#44b621"]
             ]
         }
-        
-        valueTile("temperature2", "device.temperature", decoration: "flat", inactiveLabel: false) {
-            state "temperature", label:'${currentValue}°', icon: "st.Weather.weather2",
-                backgroundColors:[
-                    [value: 0, color: "#153591"],
-                    [value: 5, color: "#1e9cbb"],
-                    [value: 10, color: "#90d2a7"],
-                    [value: 15, color: "#44b621"],
-                    [value: 20, color: "#f1d801"],
-                    [value: 25, color: "#d04e00"],
-                    [value: 30, color: "#bc2323"],
-                    [value: 44, color: "#1e9cbb"],
-                    [value: 59, color: "#90d2a7"],
-                    [value: 74, color: "#44b621"],
-                    [value: 84, color: "#f1d801"],
-                    [value: 95, color: "#d04e00"],
-                    [value: 96, color: "#bc2323"]                                      
-                ]
-        }
-            valueTile("batteryRuntime", "device.batteryRuntime", inactiveLabel: false, decoration: "flat", width: 6, height: 2) {
+        valueTile("lastcheckin", "device.lastCheckin", inactiveLabel: false, decoration:"flat", width: 4, height: 1) {
+            state "lastcheckin", label:'Last Checkin:\n ${currentValue}'
+        }     
+        valueTile("batteryRuntime", "device.batteryRuntime", inactiveLabel: false, decoration: "flat", width: 4, height: 1) {
             state "batteryRuntime", label:'Battery Changed: ${currentValue}'
-    }     
-        main(["temperature2"])
-        details(["temperature", "battery", "humidity","batteryRuntime"])
+        }     
+        main("temperature2")
+        details(["temperature", "battery", "humidity", "lastcheckin", "batteryRuntime"])
     }
     preferences {
-        section {
-            //input description: "The settings below customize additional infomation displayed in the main status tile.", type: "paragraph", element: "paragraph", title: "MAIN TILE DISPLAY"
-            //input name: "displayTempInteger", type: "bool", title: "Display temperature as integer?", defaultValue: false
-            //input name: "displayTempHighLow", type: "bool", title: "Display high/low temperature?", defaultValue: false
-            //input name: "displayHumidHighLow", type: "bool", title: "Display high/low humidity?", defaultValue: false
-        }
-        section {
-            input description: "The settings below allow correction of variations in temperature, humidity, and pressure by setting an offset. Examples: If the sensor consistently reports temperature 5 degrees too warm, enter '-5' for the Temperature Offset. If it reports humidity 3% too low, enter ‘3' for the Humidity Offset. NOTE: Changes will take effect on the NEXT temperature / humidity / pressure report.", type: "paragraph", element: "paragraph", title: "OFFSETS & UNITS"
-            input "tempOffset", "number", title:"Temperature Offset", description:"Adjust temperature by this many degrees", range:"*..*"
-            input "humidOffset", "number", title:"Humidity Offset", description:"Adjust humidity by this many percent", range: "*..*"
-            //input "pressOffset", "number", title:"Pressure Offset", description:"Adjust pressure by this many units", range: "*..*"
-            //input name:"PressureUnits", type:"enum", title:"Pressure Units", options:["mbar", "kPa", "inHg", "mmHg"], description:"Sets the unit in which pressure will be reported"
-            input description: "NOTE: The temperature unit (C / F) can be changed in the location settings for your hub.", type: "paragraph", element: "paragraph", title: ""
-        }
-        section {
-            input description: "", type: "paragraph", element: "paragraph", title: "DATE & CLOCK"    
-            input name: "dateformat", type: "enum", title: "Set Date Format\n US (MDY) - UK (DMY) - Other (YMD)", description: "Date Format", options:["US","UK","Other"]
-            input name: "clockformat", type: "bool", title: "Use 24 hour clock?", defaultValue: false
-        }
-        section {
-            input description: "If you have installed a new battery, the toggle below will reset the Changed Battery date to help remember when it was changed.", type: "paragraph", element: "paragraph", title: "CHANGED BATTERY DATE RESET"
-            input name: "battReset", type: "bool", title: "Battery Changed?", description: ""
-        }
-        section {
-            input description: "Only change the settings below if you know what you're doing.", type: "paragraph", element: "paragraph", title: "ADVANCED SETTINGS"
-            input name: "voltsmax", title: "Max Volts\nA battery is at 100% at __ volts.\nRange 2.8 to 3.4", type: "decimal", range: "2.8..3.4", defaultValue: 3
-            input name: "voltsmin", title: "Min Volts\nA battery is at 0% (needs replacing)\nat __ volts.  Range 2.0 to 2.7", type: "decimal", range: "2..2.7", defaultValue: 2.5
-        }
+		//Button Config
+		input description: "The settings below customize additional infomation displayed in the main status tile.", type: "paragraph", element: "paragraph", title: "MAIN TILE DISPLAY"
+		input name: "displayTempInteger", type: "bool", title: "Display temperature as integer?"
+		input name: "displayTempHighLow", type: "bool", title: "Display high/low temperature?"
+		input name: "displayHumidHighLow", type: "bool", title: "Display high/low humidity?"
+		//Temp and Humidity Offsets
+		input description: "The settings below allow correction of variations in temperature and humidity by setting an offset. Examples: If the sensor consistently reports temperature 5 degrees too warm, enter '-5' for the Temperature Offset. If it reports humidity 3% too low, enter ‘3' for the Humidity Offset. NOTE: Changes will take effect on the NEXT temperature / humidity / pressure report.", type: "paragraph", element: "paragraph", title: "OFFSETS & UNITS"
+		input "tempOffset", "number", title:"Temperature Offset", description:"Adjust temperature by this many degrees", range:"*..*"
+		input "humidOffset", "number", title:"Humidity Offset", description:"Adjust humidity by this many percent", range: "*..*"
+		input description: "NOTE: The temperature unit (C / F) can be changed in the location settings for your hub.", type: "paragraph", element: "paragraph", title: ""
+		//Date & Time Config
+		input description: "", type: "paragraph", element: "paragraph", title: "DATE & CLOCK"    
+		input name: "dateformat", type: "enum", title: "Set Date Format\n US (MDY) - UK (DMY) - Other (YMD)", description: "Date Format", options:["US","UK","Other"]
+		input name: "clockformat", type: "bool", title: "Use 24 hour clock?"
+		//Battery Reset Config
+		input description: "If you have installed a new battery, the toggle below will reset the Changed Battery date to help remember when it was changed.", type: "paragraph", element: "paragraph", title: "CHANGED BATTERY DATE RESET"
+		input name: "battReset", type: "bool", title: "Battery Changed?", description: ""
+		//Battery Voltage Offset
+		input description: "Only change the settings below if you know what you're doing.", type: "paragraph", element: "paragraph", title: "ADVANCED SETTINGS"
+		input name: "voltsmax", title: "Max Volts\nA battery is at 100% at __ volts.\nRange 2.8 to 3.4", type: "decimal", range: "2.8..3.4", defaultValue: 3
+		input name: "voltsmin", title: "Min Volts\nA battery is at 0% (needs replacing)\nat __ volts.  Range 2.0 to 2.7", type: "decimal", range: "2..2.7", defaultValue: 2.5
 	}
 }
 
 // Parse incoming device messages to generate events
 def parse(String description) {
+    log.debug "${device.displayName}: Parsing description: ${description}"
 
 	// Determine current time and date in the user-selected date format and clock style
     def now = formatDate()    
     def nowDate = new Date(now).getTime()
+
 	// Any report - temp, humidity, pressure, & battery - results in a lastCheckin event and update to Last Checkin tile
 	// However, only a non-parseable report results in lastCheckin being displayed in events log
     sendEvent(name: "lastCheckin", value: now, displayed: false)
     sendEvent(name: "lastCheckinDate", value: nowDate, displayed: false)
 
-    Map map = [:]
+	// Check if the min/max temp and min/max humidity should be reset
+    checkNewDay(now)
+
+	// getEvent automatically retrieves temp and humidity in correct unit as integer
+	Map map = zigbee.getEvent(description)
 
 	// Send message data to appropriate parsing function based on the type of report
-    if (description?.startsWith("temperature: ")) {
-        map = parseTemperature(description)
-    } else if (description?.startsWith("humidity: ")) {
-        map = parseHumidity(description)
-    } else if (description?.startsWith('catchall:')) {
-        map = parseCatchAllMessage(description)
-    } else if (description?.startsWith('read attr - raw:')) {
-        map = parseReadAttr(description)
-    }
+	if (map.name == "temperature") {
+        def temp = parseTemperature(description)
+		map.value = displayTempInteger ? (int) temp : temp
+		map.descriptionText = "${device.displayName} temperature is ${map.value}°${temperatureScale}"
+		map.translatable = true
+		updateMinMaxTemps(map.value)
+	} else if (map.name == "humidity") {
+		if (humidityOffset) {
+			map.value = (int) map.value + (int) humidityOffset
+		}
+		updateMinMaxHumidity(map.value)
+	} else if (description?.startsWith('catchall:')) {
+		map = parseCatchAllMessage(description)
+	} else if (description?.startsWith('read attr - raw:')) {
+		map = parseReadAttr(description)
+	} else {
+		log.debug "${device.displayName}: was unable to parse ${description}"
+        sendEvent(name: "lastCheckin", value: now) 
+	}
 
-    log.debug "${device.displayName}: Parse returned ${map}"
-    def results = map ? createEvent(map) : null
-    return results
+	if (map) {
+		log.debug "${device.displayName}: Parse returned ${map}"
+		return createEvent(map)
+	} else
+		return [:]
 }
 
-
-private Map parseTemperature(String description){
-    def temp = ((description - "temperature: ").trim()) as Float 
-
-    if (!(settings.tempOffset)){
-        settings.tempOffset = 0
-    }
-    
-    if (temp > 100)
-    {
-        temp = 100.0 - temp
-    }
-    
-    if (getTemperatureScale() == "C") {
-        if (settings.tempOffset) {
-            temp = (Math.round(temp * 10))/ 10 + settings.tempOffset as Float
-        } else {
-            temp = (Math.round(temp * 10))/ 10 as Float
-        }
-    } else {
-        if (settings.tempOffset) {
-            temp = (Math.round((temp * 90.0)/5.0))/10.0 + 32.0 + settings.tempOffset as Float
-        } else {
-            temp = (Math.round((temp * 90.0)/5.0))/10.0 + 32.0 as Float
-        }
-    }
-    def units = getTemperatureScale()
-    
-    if(temp > device.currentValue("maxTemp"))
-	sendEvent(name: "maxTemp", value: temp, displayed: false)
-	
-    if(temp < device.currentValue("minTemp"))
-	sendEvent(name: "minTemp", value: temp, displayed: false)
-	
-    def result = [
-        name: 'temperature',
-        value: temp,
-        unit: units,
-        isStateChange:true,
-        descriptionText : "${device.displayName} temperature is ${temp}${units}"
-    ]
-    return result
-}
-
-
-private Map parseHumidity(String description){
-    def pct = (description - "humidity: " - "%").trim()
-
-    if (!(settings.humidOffset)) {
-        settings.humidOffset = 0
-    }
-    if (pct.isNumber()) {
-        pct =  Math.round(new BigDecimal(pct + settings.humidOffset))
-        
-        def result = [
-            name: 'humidity',
-            value: pct,
-            unit: "%",
-            isStateChange:true,
-            descriptionText : "${device.displayName} Humidity is ${pct}%"
-        ]
-        return result
-    }
-    return [:]
+// Calculate temperature with 0.1 precision in C or F unit as set by hub location settings
+private parseTemperature(String description) {
+	def temp = ((description - "temperature: ").trim()) as Float
+	def offset = tempOffset ? tempOffset : 0
+	temp = (temp > 100) ? (100 - temp) : temp
+    temp = (temperatureScale == "F") ? ((temp * 1.8) + 32) + offset : temp + offset
+	return temp.round(1)
 }
 
 // Check catchall for battery voltage data to pass to getBatteryResult for conversion to percentage report
@@ -293,31 +259,25 @@ private Map parseCatchAllMessage(String description) {
     return resultMap
 }
 
-// Parse raw data on reset button press to retrieve reported battery voltage
+// Parse device name on short press of reset button
 private Map parseReadAttr(String description) {
     Map resultMap = [:]
 
     def cluster = description.split(",").find {it.split(":")[0].trim() == "cluster"}?.split(":")[1].trim()
     def attrId = description.split(",").find {it.split(":")[0].trim() == "attrId"}?.split(":")[1].trim()
     def value = description.split(",").find {it.split(":")[0].trim() == "value"}?.split(":")[1].trim()
-    def model = value.split("01FF")[0]
-    def data = value.split("01FF")[1]
 
     if (cluster == "0000" && attrId == "0005")  {
         def modelName = ""
-        // Parsing the model
-        for (int i = 0; i < model.length(); i+=2) 
-        {
-            def str = model.substring(i, i+2);
+
+        // Parsing the model name
+        for (int i = 0; i < value.length(); i+=2) {
+            def str = value.substring(i, i+2);
             def NextChar = (char)Integer.parseInt(str, 16);
             modelName = modelName + NextChar
         }
-        log.debug "${device.displayName} reported: cluster: ${cluster}, attrId: ${attrId}, value: ${value}, model:${modelName}, data:${data}"
+        log.debug "${device.displayName} reported: cluster: ${cluster}, attrId: ${attrId}, value: ${value}, model:${modelName}"
     }
-    if (data[4..7] == "0121") {
-        resultMap = getBatteryResult(Integer.parseInt((data[10..11] + data[8..9]),16))
-    }
-    return resultMap
 }
 
 // Convert raw 4 digit integer voltage value into percentage based on minVolts/maxVolts range
@@ -346,8 +306,7 @@ private Map getBatteryResult(rawValue) {
         isStateChange:true,
         descriptionText : "${device.displayName} raw battery is ${rawVolts}v"
     ]
-    
-    log.debug "${device.displayName}: ${result}"
+
     return result
 }
 
@@ -356,23 +315,68 @@ def resetBatteryRuntime() {
     sendEvent(name: "batteryRuntime", value: now)
 }
 
-def tempReset() {
-    sendEvent(name: "maxTemp", value: device.temperature, displayed: false)
-    sendEvent(name: "minTemp", value: device.temperature, displayed: false)
+// If the day of month has changed from that of previous event, reset the daily min/max temp values
+def checkNewDay(now) {
+	def oldDay = ((device.currentValue("currentDay")) == null) ? "32" : (device.currentValue("currentDay"))
+	def newDay = new Date(now).format("mm")
+	if (newDay != oldDay) {
+		resetMinMax()
+		sendEvent(name: "currentDay", value: newDay, displayed: false)
+	}
+}
+
+// Reset daily min/max temp and humidity values to the current temp/humidity values
+def resetMinMax() {
+	def currentTemp = device.currentValue('temperature')
+	def currentHumidity = device.currentValue('humidity')
+    currentTemp = currentTemp ? (int) currentTemp : currentTemp
+	log.debug "${device.displayName}: Resetting daily min/max values to current temperature of ${currentTemp}° and humidity of ${currentHumidity}%"
+    sendEvent(name: "maxTemp", value: currentTemp, displayed: false)
+    sendEvent(name: "minTemp", value: currentTemp, displayed: false)
+    sendEvent(name: "maxHumidity", value: currentHumidity, displayed: false)
+    sendEvent(name: "minHumidity", value: currentHumidity, displayed: false)
+    refreshMultiAttributes()
+}
+
+// Check new min or max temp for the day
+def updateMinMaxTemps(temp) {
+	temp = temp ? (int) temp : temp
+	if ((temp > device.currentValue('maxTemp')) || (device.currentValue('maxTemp') == null))
+		sendEvent(name: "maxTemp", value: temp, displayed: false)	
+	if ((temp < device.currentValue('minTemp')) || (device.currentValue('minTemp') == null))
+		sendEvent(name: "minTemp", value: temp, displayed: false)
+	refreshMultiAttributes()
+}
+
+// Check new min or max humidity for the day
+def updateMinMaxHumidity(humidity) {
+	if ((humidity > device.currentValue('maxHumidity')) || (device.currentValue('maxHumidity') == null))
+		sendEvent(name: "maxHumidity", value: humidity, displayed: false)
+	if ((humidity < device.currentValue('minHumidity')) || (device.currentValue('minHumidity') == null))
+		sendEvent(name: "minHumidity", value: humidity, displayed: false)
+	refreshMultiAttributes()
+}
+
+// Update display of multiattributes in main tile
+def refreshMultiAttributes() {
+	def temphiloAttributes = displayTempHighLow ? (displayHumidHighLow ? "Today's High/Low:  ${device.currentState('maxTemp')?.value}° / ${device.currentState('minTemp')?.value}°" : "Today's High: ${device.currentState('maxTemp')?.value}°  /  Low: ${device.currentState('minTemp')?.value}°") : ""
+	def humidhiloAttributes = displayHumidHighLow ? (displayTempHighLow ? "    ${device.currentState('maxHumidity')?.value}% / ${device.currentState('minHumidity')?.value}%" : "Today's High: ${device.currentState('maxHumidity')?.value}%  /  Low: ${device.currentState('minHumidity')?.value}%") : ""
+	sendEvent(name: "multiAttributesReport", value: "${temphiloAttributes}${humidhiloAttributes}", displayed: false)
 }
 
 def configure() {
     log.debug "${device.displayName}: configure"
     state.battery = 0
     checkIntervalEvent("configure");
+    return
 }
 
 // installed() runs just after a sensor is paired using the "Add a Thing" method in the SmartThings mobile app
 def installed() {
     state.battery = 0
     resetBatteryRuntime()
+    log.debug "${device.displayName}: Setting Battery Changed to current date for newly paired sensor"
     checkIntervalEvent("installed");
-    schedule("0 0 0 * * ?", tempReset)
 }
 
 // updated() will run twice every time user presses save in preference settings page
@@ -382,9 +386,8 @@ def updated() {
 		resetBatteryRuntime()
 		device.updateSetting("battReset", false)
   }
-    //set schedule for people that already had the device installed
-    unschedule()//not sure if need but dont want to make 100s of schedules
-    schedule("0 0 0 * * ?", tempReset)
+	updateMinMaxTemps(device.currentValue('temperature'))
+	updateMinMaxHumidity(device.currentValue('humidity'))
 }
 
 private checkIntervalEvent(text) {
@@ -406,6 +409,7 @@ def formatDate(batteryReset) {
     else {
         correctedTimezone = location.timeZone
     }
+
     if (dateformat == "US" || dateformat == "" || dateformat == null) {
         if (batteryReset)
             return new Date().format("MMM dd yyyy", correctedTimezone)

--- a/devicetypes/bspranger/xiaomi-temperature-humidity-sensor.src/xiaomi-temperature-humidity-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-temperature-humidity-sensor.src/xiaomi-temperature-humidity-sensor.groovy
@@ -128,7 +128,7 @@ metadata {
             ]
         }
         valueTile("lastcheckin", "device.lastCheckin", inactiveLabel: false, decoration:"flat", width: 4, height: 1) {
-            state "lastcheckin", label:'Last Checkin:\n ${currentValue}'
+            state "lastcheckin", label:'Last Event:\n ${currentValue}'
         }     
         valueTile("batteryRuntime", "device.batteryRuntime", inactiveLabel: false, decoration: "flat", width: 4, height: 1) {
             state "batteryRuntime", label:'Battery Changed: ${currentValue}'

--- a/devicetypes/bspranger/xiaomi-temperature-humidity-sensor.src/xiaomi-temperature-humidity-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-temperature-humidity-sensor.src/xiaomi-temperature-humidity-sensor.groovy
@@ -371,6 +371,7 @@ def configure() {
 
 def installed() {
     state.battery = 0
+    resetBatteryRuntime()
     checkIntervalEvent("installed");
     schedule("0 0 0 * * ?", tempReset)
 }

--- a/devicetypes/bspranger/xiaomi-temperature-humidity-sensor.src/xiaomi-temperature-humidity-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-temperature-humidity-sensor.src/xiaomi-temperature-humidity-sensor.groovy
@@ -224,44 +224,24 @@ private parseTemperature(String description) {
 
 // Check catchall for battery voltage data to pass to getBatteryResult for conversion to percentage report
 private Map parseCatchAllMessage(String description) {
-    def i
-    Map resultMap = [:]
-    def cluster = zigbee.parse(description)
-    log.debug cluster
-    if (cluster) {
-        switch(cluster.clusterId) 
-        {
-            case 0x0000:
-                def MsgLength = cluster.data.size();
+	Map resultMap = [:]
+	def catchall = zigbee.parse(description)
+	log.debug catchall
 
-                // Original Xiaomi CatchAll does not have identifiers, first UINT16 is Battery
-                if ((cluster.data.get(0) == 0x02) && (cluster.data.get(1) == 0xFF))
-                {
-                    for (i = 0; i < (MsgLength-3); i++)
-                    {
-                        if (cluster.data.get(i) == 0x21) // check the data ID and data type
-                        {
-                            // next two bytes are the battery voltage.
-                            resultMap = getBatteryResult((cluster.data.get(i+2)<<8) + cluster.data.get(i+1))
-                            break
-                        }
-                    }
-                }else if ((cluster.data.get(0) == 0x01) && (cluster.data.get(1) == 0xFF))
-                {
-                    for (i = 0; i < (MsgLength-3); i++)
-                    {
-                        if ((cluster.data.get(i) == 0x01) && (cluster.data.get(i+1) == 0x21))  // check the data ID and data type
-                        {
-                            // next two bytes are the battery voltage.
-                            resultMap = getBatteryResult((cluster.data.get(i+3)<<8) + cluster.data.get(i+2))
-                            break
-                        }
-                    }
-                }
-            break
-        }
-    }
-    return resultMap
+	if (catchall.clusterId == 0x0000) {
+		def MsgLength = catchall.data.size()
+		// Xiaomi CatchAll does not have identifiers, first UINT16 is Battery
+		if ((catchall.data.get(0) == 0x01 || catchall.data.get(0) == 0x02) && (catchall.data.get(1) == 0xFF)) {
+			for (int i = 4; i < (MsgLength-3); i++) {
+				if (catchall.data.get(i) == 0x21) { // check the data ID and data type
+					// next two bytes are the battery voltage
+					resultMap = getBatteryResult((catchall.data.get(i+2)<<8) + catchall.data.get(i+1))
+				}
+			break
+			}
+		}
+	}
+	return resultMap
 }
 
 // Parse device name on short press of reset button

--- a/devicetypes/bspranger/xiaomi-temperature-humidity-sensor.src/xiaomi-temperature-humidity-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-temperature-humidity-sensor.src/xiaomi-temperature-humidity-sensor.groovy
@@ -317,11 +317,6 @@ private Map getBatteryResult(rawValue) {
     return result
 }
 
-def resetBatteryRuntime() {
-    def now = formatDate(true)    
-    sendEvent(name: "batteryRuntime", value: now)
-}
-
 // If the day of month has changed from that of previous event, reset the daily min/max temp values
 def checkNewDay(now) {
 	def oldDay = ((device.currentValue("currentDay")) == null) ? "32" : (device.currentValue("currentDay"))
@@ -371,30 +366,37 @@ def refreshMultiAttributes() {
 	sendEvent(name: "multiAttributesReport", value: "${temphiloAttributes}${humidhiloAttributes}", displayed: false)
 }
 
-def configure() {
-    log.debug "${device.displayName}: configure"
-    state.battery = 0
-    checkIntervalEvent("configure");
-    return
+//Reset the date displayed in Battery Changed tile to current date
+def resetBatteryRuntime(paired) {
+	def now = formatDate(true)
+	def newlyPaired = paired ? " for newly paired sensor" : ""
+	sendEvent(name: "batteryRuntime", value: now)
+	log.debug "${device.displayName}: Setting Battery Changed to current date${newlyPaired}"
 }
 
 // installed() runs just after a sensor is paired using the "Add a Thing" method in the SmartThings mobile app
 def installed() {
-    state.battery = 0
-    resetBatteryRuntime()
-    log.debug "${device.displayName}: Setting Battery Changed to current date for newly paired sensor"
-    checkIntervalEvent("installed");
+	state.battery = 0
+	if (!batteryRuntime) resetBatteryRuntime(true)
+	checkIntervalEvent("installed")
+}
+
+// configure() runs after installed() when a sensor is paired
+def configure() {
+	log.debug "${device.displayName}: configuring"
+		state.battery = 0
+	if (!batteryRuntime) resetBatteryRuntime(true)
+	checkIntervalEvent("configured")
+	return
 }
 
 // updated() will run twice every time user presses save in preference settings page
 def updated() {
-    checkIntervalEvent("updated");
-	if(battReset){
+		checkIntervalEvent("updated")
+		if(battReset){
 		resetBatteryRuntime()
 		device.updateSetting("battReset", false)
-  }
-	updateMinMaxTemps(device.currentValue('temperature'))
-	updateMinMaxHumidity(device.currentValue('humidity'))
+	}
 }
 
 private checkIntervalEvent(text) {

--- a/devicetypes/bspranger/xiaomi-temperature-humidity-sensor.src/xiaomi-temperature-humidity-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-temperature-humidity-sensor.src/xiaomi-temperature-humidity-sensor.groovy
@@ -282,8 +282,10 @@ private Map parseReadAttr(String description) {
 
 // Convert raw 4 digit integer voltage value into percentage based on minVolts/maxVolts range
 private Map getBatteryResult(rawValue) {
-    def rawVolts = rawValue / 1000
-	def minVolts
+    // raw voltage is normally supplied as a 4 digit integer that needs to be divided by 1000
+    // but in the case the final zero is dropped then divide by 100 to get actual voltage value 
+    def rawVolts = (rawValue < 1000) ? (rawValue / 100) : (rawValue / 1000)
+    def minVolts
     def maxVolts
 
     if(voltsmin == null || voltsmin == "")


### PR DESCRIPTION
I have updated all DH's to match all the changes veeceeoh made to the Aqara temp this includes

- Moved the `preferences{} `section down to the bottom of` metadata{}`, below `tiles{}`, following the convention of the SmartThings Developer Documentation
- removed RequiredAtSetup from preferences{} section (it's only needed for SmartApps)
- removed displayDuringSetup: false because they aren't necessary
- Completely reorganized the preference page into distinct groups, with some reordering, and also changes to the text to remove redundant explanations and make them more concise. (screenshots below)
- lastCheckIn updates are no longer listed in the Events log ("Recently" tab of the ST mobile app) 
- Added code so that when the sensor is first paired, the Battery Changed is set to the current date
- I have renamed "Last Checkin" tile label to "Last Event" 