### PR TITLE
Update xiaomi-button.groovy - closed / duplicative

### DIFF
--- a/devicetypes/bspranger/xiaomi-button.src/xiaomi-button.groovy
+++ b/devicetypes/bspranger/xiaomi-button.src/xiaomi-button.groovy
@@ -96,9 +96,8 @@ metadata {
         details(["button","battery","lastcheckin","batteryRuntime"])
    }
    preferences {
-	section {	
-		input name: "holdTime", "number", title: "Minimum time in seconds for a press to count as \"held\"", defaultValue: 4
-        	input name: "PressType", type: "enum", options: ["Toggle", "Momentary"], description: "Effects how the button toggles", defaultValue: "Toggle"
+	section {
+        	input name: "PressType", type: "enum", options: ["Momentary", "Toggle"], title: "Momentary or toggle? ", defaultValue: "Momentary"
 		}
 	section {
 		input description: "", type: "paragraph", element: "paragraph", title: "DATE & CLOCK"    


### PR DESCRIPTION
- removed "held"  preference until/unless we decide to reinstate the functionality in this version of the button 
- the momentary/ toggle needed "description" changed to "title" -  while I was at it - I made description shorter and - I really think that "Momentary"  is a better default  - push and release is clear when it's working - toggle is confusing and looks like it's stuck if you weren't expecting it  - feel free to disagree, though

I have tested this in IDE