### PR TITLE
Alec - both button changes around toggle/momentary preference and remove held preference on original button

### DIFF
--- a/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
@@ -99,7 +99,7 @@ metadata {
    preferences {
 	section {	
 		input name:"ReleaseTime", type:"number", title:"Minimum time in seconds for a press to clear", defaultValue: 2
-        	input name:"PressType", type:"enum", options:["Toggle", "Momentary"], description:"Effects how the button toggles", defaultValue:"Toggle"
+        	input name: "PressType", type: "enum", options: ["Momentary", "Toggle"], title: "Momentary or toggle? ", defaultValue: "Momentary"
 		}
 	section {
 		input description: "", type: "paragraph", element: "paragraph", title: "DATE & CLOCK"    

--- a/devicetypes/bspranger/xiaomi-button.src/xiaomi-button.groovy
+++ b/devicetypes/bspranger/xiaomi-button.src/xiaomi-button.groovy
@@ -96,9 +96,8 @@ metadata {
         details(["button","battery","lastcheckin","batteryRuntime"])
    }
    preferences {
-	section {	
-		input name: "holdTime", "number", title: "Minimum time in seconds for a press to count as \"held\"", defaultValue: 4
-        	input name: "PressType", type: "enum", options: ["Toggle", "Momentary"], description: "Effects how the button toggles", defaultValue: "Toggle"
+	section {
+        	input name: "PressType", type: "enum", options: ["Momentary", "Toggle"], title: "Momentary or toggle? ", defaultValue: "Momentary"
 		}
 	section {
 		input description: "", type: "paragraph", element: "paragraph", title: "DATE & CLOCK"    


### PR DESCRIPTION
For both buttons: 
For toggle preference needs to change from "description" to "title"  - also shortened text and made "momentary"  the default  -  I think it's less confusing- feel free to disagree , though, in which case "description" still needs to change to "title"

For original button:
Removed preference for 'held'  unless/until we decide to reinstate its functionality.