### PR TITLE
Code overhaul of both motion detector DTHs (Needs testing)

### DIFF
--- a/devicetypes/bspranger/xiaomi-aqara-motion-sensor.src/xiaomi-aqara-motion-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-motion-sensor.src/xiaomi-aqara-motion-sensor.groovy
@@ -69,7 +69,7 @@ metadata {
             state "default", label:''
         }
         valueTile("illuminance", "device.illuminance", decoration:"flat", inactiveLabel: false, width: 2, height: 2) {
-            state "default", label:'${currentValue}\nlux', unit:"lux",
+            state "default", label:'${currentValue}\nlux', unit:"lux"
         }
         standardTile("reset", "device.reset", inactiveLabel: false, decoration:"flat", width: 2, height: 2) {
             state "default", action:"stopMotion", label:'Reset Motion', icon:"st.motion.motion.active"

--- a/devicetypes/bspranger/xiaomi-aqara-motion-sensor.src/xiaomi-aqara-motion-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-motion-sensor.src/xiaomi-aqara-motion-sensor.groovy
@@ -187,23 +187,23 @@ private Map parseCatchAllMessage(String description) {
     def i
     Map resultMap = [:]
     def catchall = zigbee.parse(description)
-    log.debug cluster
+    log.debug catchall
     if (catchall.clusterId == 0x0000) {
-		def MsgLength = cluster.data.size();
+		def MsgLength = catchall.data.size();
 		// Original Xiaomi CatchAll does not have identifiers, first UINT16 is Battery
-		if ((cluster.data.get(0) == 0x02) && (cluster.data.get(1) == 0xFF)) {
+		if ((catchall.data.get(0) == 0x02) && (catchall.data.get(1) == 0xFF)) {
 			for (i = 0; i < (MsgLength-3); i++) {
-				if (cluster.data.get(i) == 0x21) { // check the data ID and data type
+				if (catchall.data.get(i) == 0x21) { // check the data ID and data type
 					// next two bytes are the battery voltage
-					resultMap = getBatteryResult((cluster.data.get(i+2)<<8) + cluster.data.get(i+1))
+					resultMap = getBatteryResult((catchall.data.get(i+2)<<8) + catchall.data.get(i+1))
 				}
 			}
 		}
-		else if ((cluster.data.get(0) == 0x01) && (cluster.data.get(1) == 0xFF)) {
+		else if ((catchall.data.get(0) == 0x01) && (catchall.data.get(1) == 0xFF)) {
 			for (i = 0; i < (MsgLength-3); i++) {
-				if ((cluster.data.get(i) == 0x01) && (cluster.data.get(i+1) == 0x21)) { // check the data ID and data type
+				if ((catchall.data.get(i) == 0x01) && (catchall.data.get(i+1) == 0x21)) { // check the data ID and data type
 					// next two bytes are the battery voltage.
-					resultMap = getBatteryResult((cluster.data.get(i+3)<<8) + cluster.data.get(i+2))
+					resultMap = getBatteryResult((catchall.data.get(i+3)<<8) + catchall.data.get(i+2))
 				}
 			}
 		}

--- a/devicetypes/bspranger/xiaomi-aqara-motion-sensor.src/xiaomi-aqara-motion-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-motion-sensor.src/xiaomi-aqara-motion-sensor.groovy
@@ -86,7 +86,8 @@ metadata {
 	}
 	preferences {
 		//Reset to No Motion Config
-		input "motionreset", "number", title: "Enter the number of seconds of inactivity required before resetting to 'no motion'", description: "Range 1-60 (default is 7)", range: "1..60"
+		input description: "This setting only changes how long MOTION DETECTED is reported in SmartThings. The sensor hardware always remains blind to motion for 60 seconds after any activity.", type: "paragraph", element: "paragraph", title: "MOTION RESET"
+		input "motionreset", "number", title: "", description: "Enter number of seconds (default = 60)", range: "1..7200"
 		//Date & Time Config
 		input description: "", type: "paragraph", element: "paragraph", title: "DATE & CLOCK"    
 		input name: "dateformat", type: "enum", title: "Set Date Format\n US (MDY) - UK (DMY) - Other (YMD)", description: "Date Format", options:["US","UK","Other"]
@@ -158,7 +159,7 @@ private Map parseReportAttributeMessage(String description) {
 	// The sensor only sends a motion detected message so the reset to no motion is performed in code
     if ((cluster == "0406") & (value == "01")) {
 		log.debug "${device.displayName} detected motion"
-		def seconds = motionreset ? motionreset : 7
+		def seconds = motionreset ? motionreset : 60
 		resultMap = [
 			name: 'motion',
 			value: 'active',

--- a/devicetypes/bspranger/xiaomi-aqara-motion-sensor.src/xiaomi-aqara-motion-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-motion-sensor.src/xiaomi-aqara-motion-sensor.groovy
@@ -37,13 +37,11 @@ metadata {
         attribute "light", "number"
         attribute "batteryRuntime", "String"
 
-        fingerprint profileId: "0104", deviceId: "0104", inClusters: "0000, 0003, FFFF, 0019", outClusters: "0000, 0004, 0003, 0006, 0008, 0005, 0019", manufacturer: "LUMI", model: "lumi.sensor_motion", deviceJoinName: "Xiaomi Motion"
         fingerprint endpointId: "01", profileId: "0104", deviceId: "0107", inClusters: "0000,FFFF,0406,0400,0500,0001,0003", outClusters: "0000,0019", manufacturer: "LUMI", model: "lumi.sensor_motion.aq2", deviceJoinName: "Xiaomi Aqara Motion Sensor"
-	fingerprint profileID: "0104", deviceId: "0104", inClusters: "0000, 0400, 0406, FFFF", outClusters: "0000,0019", manufacturer: "LUMI", model: "lumi.sensor_motion", deviceJoinName: "Xiaomi Aqara Motion Sensor"
+        fingerprint profileId: "0104", deviceId: "0104", inClusters: "0000, 0400, 0406, FFFF", outClusters: "0000, 0019", manufacturer: "LUMI", model: "lumi.sensor_motion", deviceJoinName: "Xiaomi Aqara Motion Sensor"
 
         command "resetBatteryRuntime"
-        command "reset"
-        command "Refresh"
+        command "stopMotion"
     }
 
     simulator {
@@ -68,13 +66,13 @@ metadata {
             ]
         }
         valueTile("spacer", "spacer", decoration: "flat", inactiveLabel: false, width: 1, height: 1) {
-	    state "default", label:''
+            state "default", label:''
         }
         valueTile("illuminance", "device.illuminance", decoration:"flat", inactiveLabel: false, width: 2, height: 2) {
-            state "default", label:'${currentValue} lux', unit:"lux"
+            state "default", label:'${currentValue}\nlux', unit:"lux"
         }
         standardTile("reset", "device.reset", inactiveLabel: false, decoration:"flat", width: 2, height: 2) {
-            state "default", action:"reset", label:'Reset Motion', icon:"st.motion.motion.active"
+            state "default", action:"stopMotion", label:'Reset Motion', icon:"st.motion.motion.active"
         }
         valueTile("lastcheckin", "device.lastCheckin", decoration:"flat", inactiveLabel: false, width: 4, height: 1) {
             state "default", label:'Last Event:\n ${currentValue}'
@@ -83,33 +81,34 @@ metadata {
              state "batteryRuntime", label:'Battery Changed:\n ${currentValue}'
         }
 
-        main(["motion"])
-        details(["motion", "battery", "illuminance", "reset", "spacer", "lastcheckin", "spacer", "spacer", "batteryRuntime", "spacer"])
-    }
-   preferences {
-		//motion Time out
-	        input name: "motionReset", "number", title: "Number of seconds after the last reported activity to report that motion is inactive (in seconds). \n\n(The device will always remain blind to motion for 60seconds following first detected motion. This value just clears the 'active' status after the number of seconds you set here but the device will still remain blind for 60seconds in normal operation.)", description: "", defaultValue:120
+		main(["motion"])
+		details(["motion", "battery", "illuminance", "reset", "spacer", "lastcheckin", "spacer", "spacer", "batteryRuntime", "spacer"])
+	}
+	preferences {
+		//Reset to No Motion Config
+		input "motionreset", "number", title: "Enter the number of seconds of inactivity required before resetting to 'no motion'", description: "Range 1-60 (default is 7)", range: "1..60"
 		//Date & Time Config
 		input description: "", type: "paragraph", element: "paragraph", title: "DATE & CLOCK"    
 		input name: "dateformat", type: "enum", title: "Set Date Format\n US (MDY) - UK (DMY) - Other (YMD)", description: "Date Format", options:["US","UK","Other"]
 		input name: "clockformat", type: "bool", title: "Use 24 hour clock?"
 		//Battery Reset Config
-            	input description: "If you have installed a new battery, the toggle below will reset the Changed Battery date to help remember when it was changed.", type: "paragraph", element: "paragraph", title: "CHANGED BATTERY DATE RESET"
+		input description: "If you have installed a new battery, the toggle below will reset the Changed Battery date to help remember when it was changed.", type: "paragraph", element: "paragraph", title: "CHANGED BATTERY DATE RESET"
 		input name: "battReset", type: "bool", title: "Battery Changed?"
 		//Battery Voltage Offset
-	        input description: "Only change the settings below if you know what you're doing.", type: "paragraph", element: "paragraph", title: "ADVANCED SETTINGS"
-		input name: "voltsmax", title: "Max Volts\nA battery is at 100% at __ volts\nRange 2.8 to 3.4", type: "decimal", range: "2.8..3.4", defaultValue: 3, required: false
-		input name: "voltsmin", title: "Min Volts\nA battery is at 0% (needs replacing) at __ volts\nRange 2.0 to 2.7", type: "decimal", range: "2..2.7", defaultValue: 2.5, required: false
-  }	
+		input description: "Only change the settings below if you know what you're doing.", type: "paragraph", element: "paragraph", title: "ADVANCED SETTINGS"
+		input name: "voltsmax", title: "Max Volts\nA battery is at 100% at __ volts\nRange 2.8 to 3.4", type: "decimal", range: "2.8..3.4", defaultValue: 3
+		input name: "voltsmin", title: "Min Volts\nA battery is at 0% (needs replacing) at __ volts\nRange 2.0 to 2.7", type: "decimal", range: "2..2.7", defaultValue: 2.5
+	}	
 }
 
 // Parse incoming device messages to generate events
 def parse(String description) {
-    log.debug "${device.displayName} Parsing: $description"
+    log.debug "${device.displayName} parsing: $description"
 
-    // Determine current time and date in the user-selected date format and clock style
+	// Determine current time and date in the user-selected date format and clock style
     def now = formatDate()    
     def nowDate = new Date(now).getTime()
+
 	// Any report - motion, lux & Battery - results in a lastCheckin event and update to Last Checkin tile
 	// However, only a non-parseable report results in lastCheckin being displayed in events log
     sendEvent(name: "lastCheckin", value: now, displayed: false)
@@ -117,39 +116,98 @@ def parse(String description) {
 
     Map map = [:]
 	
-    // Send message data to appropriate parsing function based on the type of report	
-    if (description?.startsWith('catchall:')) {
-        map = parseCatchAllMessage(description)
+	// Send message data to appropriate parsing function based on the type of report	
+    if (description?.startsWith('illuminance:')) {
+        map = parseIlluminance(description)
     }
     else if (description?.startsWith('read attr -')) {
         map = parseReportAttributeMessage(description)
     }
-    else if (description?.startsWith('illuminance:')) {
-        map = parseIlluminanceMessage(description)
-    }
-    else if (description?.startsWith('enroll request')) {
-        List cmds = enrollResponse()
-        log.debug "${device.displayName} enroll response: ${cmds}"
-        result = cmds?.collect { new physicalgraph.device.HubAction(it) }
+    else if (description?.startsWith('catchall:')) {
+        map = parseCatchAllMessage(description)
     }
 
-    log.debug "${device.displayName} Parse returned: $map"
+    log.debug "${device.displayName} parse returned: $map"
     def result = map ? createEvent(map) : null
 
     return result
 }
 
-private Map parseIlluminanceMessage(String description) {
-    def Lux = ((description - "illuminance: ").trim()) as Float
+// Parse illuminance report
+private Map parseIlluminance(String description) {
+    def lux = ((description - "illuminance: ").trim()) as int
 
     def result = [
         name: 'illuminance',
-        value: Lux,
+        value: lux,
         unit: "lux",
-        isStateChange:true,
-        descriptionText : "${device.displayName} illuminance was ${Lux} lux"
+        isStateChange: true,
+        descriptionText : "${device.displayName} illuminance was ${lux} lux"
     ]
-    return result;
+    return result
+}
+// Parse motion active/inactive report or battery report on reset button press
+private Map parseReportAttributeMessage(String description) {
+    def cluster = description.split(",").find {it.split(":")[0].trim() == "cluster"}?.split(":")[1].trim()
+    def attrId = description.split(",").find {it.split(":")[0].trim() == "attrId"}?.split(":")[1].trim()
+    def value = description.split(",").find {it.split(":")[0].trim() == "value"}?.split(":")[1].trim()
+
+    Map resultMap = [:]
+    def now = formatDate()
+
+	// The sensor only sends a motion detected message so the reset to no motion is performed in code
+    if ((cluster == "0406") & (value == "01")) {
+		log.debug "${device.displayName} detected motion"
+		def seconds = motionreset ? motionreset : 7
+		resultMap = [
+			name: 'motion',
+			value: 'active',
+			descriptionText: "${device.displayName} detected motion"
+		]
+		sendEvent(name: "lastMotion", value: now, displayed: false)
+		runIn(seconds, stopMotion)
+	}
+	else if (cluster == "0000" && attrId == "0005") {
+        def modelName = ""
+        // Parsing the model
+        for (int i = 0; i < value.length(); i+=2)
+        {
+            def str = value.substring(i, i+2);
+            def NextChar = (char)Integer.parseInt(str, 16);
+            modelName = modelName + NextChar
+        }
+        log.debug "${device.displayName} reported: cluster: ${cluster}, attrId: ${attrId}, model:${modelName}"
+    }
+    return resultMap
+}
+
+// Check catchall for battery voltage data to pass to getBatteryResult for conversion to percentage report
+private Map parseCatchAllMessage(String description) {
+    def i
+    Map resultMap = [:]
+    def catchall = zigbee.parse(description)
+    log.debug cluster
+    if (catchall.clusterId == 0x0000) {
+		def MsgLength = cluster.data.size();
+		// Original Xiaomi CatchAll does not have identifiers, first UINT16 is Battery
+		if ((cluster.data.get(0) == 0x02) && (cluster.data.get(1) == 0xFF)) {
+			for (i = 0; i < (MsgLength-3); i++) {
+				if (cluster.data.get(i) == 0x21) { // check the data ID and data type
+					// next two bytes are the battery voltage
+					resultMap = getBatteryResult((cluster.data.get(i+2)<<8) + cluster.data.get(i+1))
+				}
+			}
+		}
+		else if ((cluster.data.get(0) == 0x01) && (cluster.data.get(1) == 0xFF)) {
+			for (i = 0; i < (MsgLength-3); i++) {
+				if ((cluster.data.get(i) == 0x01) && (cluster.data.get(i+1) == 0x21)) { // check the data ID and data type
+					// next two bytes are the battery voltage.
+					resultMap = getBatteryResult((cluster.data.get(i+3)<<8) + cluster.data.get(i+2))
+				}
+			}
+		}
+    }
+    return resultMap
 }
 
 // Convert raw 4 digit integer voltage value into percentage based on minVolts/maxVolts range
@@ -157,7 +215,7 @@ private Map getBatteryResult(rawValue) {
     // raw voltage is normally supplied as a 4 digit integer that needs to be divided by 1000
     // but in the case the final zero is dropped then divide by 100 to get actual voltage value 
     def rawVolts = (rawValue < 1000) ? (rawValue / 100) : (rawValue / 1000)
-    def minVolts
+	def minVolts
     def maxVolts
 
     if(voltsmin == null || voltsmin == "")
@@ -181,150 +239,16 @@ private Map getBatteryResult(rawValue) {
         descriptionText : "${device.displayName} raw battery is ${rawVolts}v"
     ]
 
-    log.debug "${device.displayName}: ${result}"
     return result
 }
 
-// Check catchall for battery voltage data to pass to getBatteryResult for conversion to percentage report
-private Map parseCatchAllMessage(String description) {
-    def i
-    Map resultMap = [:]
-    def cluster = zigbee.parse(description)
-    log.debug cluster
-    if (cluster) {
-        switch(cluster.clusterId)
-        {
-            case 0x0000:
-            def MsgLength = cluster.data.size();
-
-            // Original Xiaomi CatchAll does not have identifiers, first UINT16 is Battery
-            if ((cluster.data.get(0) == 0x02) && (cluster.data.get(1) == 0xFF))
-            {
-                for (i = 0; i < (MsgLength-3); i++)
-                {
-                    if (cluster.data.get(i) == 0x21) // check the data ID and data type
-                    {
-                        // next two bytes are the battery voltage.
-                        resultMap = getBatteryResult((cluster.data.get(i+2)<<8) + cluster.data.get(i+1))
-                        break
-                    }
-                }
-            }
-            else if ((cluster.data.get(0) == 0x01) && (cluster.data.get(1) == 0xFF))
-            {
-                for (i = 0; i < (MsgLength-3); i++)
-                {
-                    if ((cluster.data.get(i) == 0x01) && (cluster.data.get(i+1) == 0x21))  // check the data ID and data type
-                    {
-                        // next two bytes are the battery voltage.
-                        resultMap = getBatteryResult((cluster.data.get(i+3)<<8) + cluster.data.get(i+2))
-                        break
-                    }
-                }
-            }
-            break
-        }
-    }
-    return resultMap
-}
-
-def enrollResponse() {
-    log.debug "${device.displayName}: Enrolling device into the IAS Zone"
-    [
-        // Enrolling device into the IAS Zone
-        "raw 0x500 {01 23 00 00 00}", "delay 200",
-        "send 0x${device.deviceNetworkId} 1 1"
-    ]
-}
-
-private Map parseReportAttributeMessage(String description) {
-    def cluster = description.split(",").find {it.split(":")[0].trim() == "cluster"}?.split(":")[1].trim()
-    def attrId = description.split(",").find {it.split(":")[0].trim() == "attrId"}?.split(":")[1].trim()
-    def value = description.split(",").find {it.split(":")[0].trim() == "value"}?.split(":")[1].trim()
-
-    Map resultMap = [:]
-    def now = new Date().format("EEE MMM dd yyyy h:mm:ss a", location.timeZone)
-
-    if ((cluster == "0406") && (attrId == "0000"))
-    {
-        def motion = (value == "01") ? "active" : "inactive"
-        sendEvent(name: "lastMotion", value: now)
-        if (settings.motionReset == null || settings.motionReset == "" ) settings.motionReset = 120
-        if (motion == "active") runIn(settings.motionReset, stopMotion)
-        resultMap = getMotionResult(motion)
-    }
-    else if (cluster == "0000" && attrId == "0005")
-    {
-        def modelName = ""
-        // Parsing the model
-        for (int i = 0; i < value.length(); i+=2)
-        {
-            def str = value.substring(i, i+2);
-            def NextChar = (char)Integer.parseInt(str, 16);
-            modelName = modelName + NextChar
-        }
-        log.debug "${device.displayName} reported: cluster: ${cluster}, attrId: ${attrId}, value: ${value}, model:${modelName}"
-    }
-    return resultMap
-}
-
-private Map parseIasMessage(String description) {
-    List parsedMsg = description.split(' ')
-    String msgCode = parsedMsg[2]
-
-    Map resultMap = [:]
-    switch(msgCode) {
-        case '0x0020': // Closed/No Motion/Dry
-        resultMap = getMotionResult('inactive')
-        break
-
-        case '0x0021': // Open/Motion/Wet
-        resultMap = getMotionResult('active')
-        break
-
-        case '0x0022': // Tamper Alarm
-        log.debug '${device.displayName}: motion with tamper alarm'
-        resultMap = getMotionResult('active')
-        break
-
-        case '0x0023': // Battery Alarm
-        break
-
-        case '0x0024': // Supervision Report
-        log.debug '${device.displayName}: no motion with tamper alarm'
-        resultMap = getMotionResult('inactive')
-        break
-
-        case '0x0025': // Restore Report
-        break
-
-        case '0x0026': // Trouble/Failure
-        log.debug '${device.displayName}: motion with failure alarm'
-        resultMap = getMotionResult('active')
-        break
-
-        case '0x0028': // Test Mode
-        break
-    }
-    return resultMap
-}
-
-private Map getMotionResult(value) {
-    String descriptionText = value == 'active' ? "${device.displayName} detected motion" : "${device.displayName} motion has stopped"
-    def commands = [
-        name: 'motion',
-        value: value,
-        descriptionText: descriptionText
-    ]
-    return commands
-}
-
+// If currently in 'active' motion detected state, stopMotion() resets to 'inactive' state and displays 'no motion'
 def stopMotion() {
-    sendEvent(name:"motion", value:"inactive")
-}
-
-def reset() {
-    sendEvent(name:"motion", value:"inactive")
+	if (device.currentState('motion')?.value == "active") {
+		def seconds = motionreset ? motionreset : 7
+		sendEvent(name:"motion", value:"inactive", isStateChange: true)
+		log.debug "${device.displayName} reset to no motion after ${seconds} seconds of inactivity"
+	}
 }
 
 def resetBatteryRuntime() {
@@ -335,13 +259,15 @@ def resetBatteryRuntime() {
 def configure() {
     log.debug "${device.displayName}: configuring"
     state.battery = 0
-    checkIntervalEvent("configure");
+    checkIntervalEvent("configured");
+    return
 }
 
 // installed() runs just after a sensor is paired using the "Add a Thing" method in the SmartThings mobile app
 def installed() {
     state.battery = 0
     resetBatteryRuntime()
+    log.debug "${device.displayName}: Setting Battery Changed to current date for newly paired sensor"
     checkIntervalEvent("installed");
 }
 

--- a/devicetypes/bspranger/xiaomi-aqara-motion-sensor.src/xiaomi-aqara-motion-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-motion-sensor.src/xiaomi-aqara-motion-sensor.groovy
@@ -251,33 +251,37 @@ def stopMotion() {
 	}
 }
 
-def resetBatteryRuntime() {
-    def now = formatDate(true)
-    sendEvent(name: "batteryRuntime", value: now)
-}
-
-def configure() {
-    log.debug "${device.displayName}: configuring"
-    state.battery = 0
-    checkIntervalEvent("configured");
-    return
+//Reset the date displayed in Battery Changed tile to current date
+def resetBatteryRuntime(paired) {
+	def now = formatDate(true)
+	def newlyPaired = paired ? " for newly paired sensor" : ""
+	sendEvent(name: "batteryRuntime", value: now)
+	log.debug "${device.displayName}: Setting Battery Changed to current date${newlyPaired}"
 }
 
 // installed() runs just after a sensor is paired using the "Add a Thing" method in the SmartThings mobile app
 def installed() {
-    state.battery = 0
-    resetBatteryRuntime()
-    log.debug "${device.displayName}: Setting Battery Changed to current date for newly paired sensor"
-    checkIntervalEvent("installed");
+	state.battery = 0
+	if (!batteryRuntime) resetBatteryRuntime(true)
+	checkIntervalEvent("installed")
+}
+
+// configure() runs after installed() when a sensor is paired
+def configure() {
+	log.debug "${device.displayName}: configuring"
+		state.battery = 0
+	if (!batteryRuntime) resetBatteryRuntime(true)
+	checkIntervalEvent("configured")
+	return
 }
 
 // updated() will run twice every time user presses save in preference settings page
 def updated() {
-    checkIntervalEvent("updated");
-	if(battReset){
+		checkIntervalEvent("updated")
+		if(battReset){
 		resetBatteryRuntime()
 		device.updateSetting("battReset", false)
-	}	
+	}
 }
 
 private checkIntervalEvent(text) {

--- a/devicetypes/bspranger/xiaomi-aqara-temperature-humidity-sensor.src/xiaomi-aqara-temperature-humidity-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-temperature-humidity-sensor.src/xiaomi-aqara-temperature-humidity-sensor.groovy
@@ -358,11 +358,6 @@ private Map getBatteryResult(rawValue) {
     return result
 }
 
-def resetBatteryRuntime() {
-    def now = formatDate(true)   
-    sendEvent(name: "batteryRuntime", value: now)
-}
-
 // If the day of month has changed from that of previous event, reset the daily min/max temp values
 def checkNewDay(now) {
 	def oldDay = ((device.currentValue("currentDay")) == null) ? "32" : (device.currentValue("currentDay"))
@@ -411,28 +406,37 @@ def refreshMultiAttributes() {
     sendEvent(name: "multiAttributesReport", value: "${temphiloAttributes}${humidhiloAttributes}", displayed: false)
 }
 
-def configure() {
-    log.debug "${device.displayName}: Configuring"
-    state.battery = 0
-    checkIntervalEvent("configured");
-    return
+//Reset the date displayed in Battery Changed tile to current date
+def resetBatteryRuntime(paired) {
+	def now = formatDate(true)
+	def newlyPaired = paired ? " for newly paired sensor" : ""
+	sendEvent(name: "batteryRuntime", value: now)
+	log.debug "${device.displayName}: Setting Battery Changed to current date${newlyPaired}"
 }
 
+// installed() runs just after a sensor is paired using the "Add a Thing" method in the SmartThings mobile app
 def installed() {
-    state.battery = 0
-    resetBatteryRuntime()
-    log.debug "${device.displayName}: Setting Battery Changed to current date for newly paired sensor"
-    checkIntervalEvent("installed");
+	state.battery = 0
+	if (!batteryRuntime) resetBatteryRuntime(true)
+	checkIntervalEvent("installed")
 }
 
+// configure() runs after installed() when a sensor is paired
+def configure() {
+	log.debug "${device.displayName}: configuring"
+		state.battery = 0
+	if (!batteryRuntime) resetBatteryRuntime(true)
+	checkIntervalEvent("configured")
+	return
+}
+
+// updated() will run twice every time user presses save in preference settings page
 def updated() {
-    checkIntervalEvent("updated");
-	if(battReset){
+		checkIntervalEvent("updated")
+		if(battReset){
 		resetBatteryRuntime()
 		device.updateSetting("battReset", false)
 	}
-	updateMinMaxTemps(device.currentValue('temperature'))
-	updateMinMaxHumidity(device.currentValue('humidity'))
 }
 
 private checkIntervalEvent(text) {

--- a/devicetypes/bspranger/xiaomi-motion-sensor.src/xiaomi-motion-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-motion-sensor.src/xiaomi-motion-sensor.groovy
@@ -225,30 +225,34 @@ def stopMotion() {
 	}
 }
 
-def resetBatteryRuntime() {
-    def now = formatDate(true)    
-    sendEvent(name: "batteryRuntime", value: now)
-}
-
-def configure() {
-    log.debug "${device.displayName}: configuring"
-    state.battery = 0
-    checkIntervalEvent("configured");
-    return
+//Reset the date displayed in Battery Changed tile to current date
+def resetBatteryRuntime(paired) {
+	def now = formatDate(true)
+	def newlyPaired = paired ? " for newly paired sensor" : ""
+	sendEvent(name: "batteryRuntime", value: now)
+	log.debug "${device.displayName}: Setting Battery Changed to current date${newlyPaired}"
 }
 
 // installed() runs just after a sensor is paired using the "Add a Thing" method in the SmartThings mobile app
 def installed() {
-    state.battery = 0
-    resetBatteryRuntime()
-    log.debug "${device.displayName}: Setting Battery Changed to current date for newly paired sensor"
-    checkIntervalEvent("installed");
+	state.battery = 0
+	if (!batteryRuntime) resetBatteryRuntime(true)
+	checkIntervalEvent("installed")
+}
+
+// configure() runs after installed() when a sensor is paired
+def configure() {
+	log.debug "${device.displayName}: configuring"
+		state.battery = 0
+	if (!batteryRuntime) resetBatteryRuntime(true)
+	checkIntervalEvent("configured")
+	return
 }
 
 // updated() will run twice every time user presses save in preference settings page
 def updated() {
-    checkIntervalEvent("updated");
-	if(battReset){
+		checkIntervalEvent("updated")
+		if(battReset){
 		resetBatteryRuntime()
 		device.updateSetting("battReset", false)
 	}

--- a/devicetypes/bspranger/xiaomi-motion-sensor.src/xiaomi-motion-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-motion-sensor.src/xiaomi-motion-sensor.groovy
@@ -31,14 +31,14 @@ metadata {
         capability "Health Check" 
         
         attribute "lastCheckin", "String"
-	attribute "lastCheckinDate", "String"
+        attribute "lastCheckinDate", "String"
         attribute "lastMotion", "String"
         attribute "batteryRuntime", "String"	
 
         fingerprint profileId: "0104", deviceId: "0104", inClusters: "0000, 0003, FFFF, 0019", outClusters: "0000, 0004, 0003, 0006, 0008, 0005, 0019", manufacturer: "LUMI", model: "lumi.sensor_motion", deviceJoinName: "Xiaomi Motion"
         
         command "resetBatteryRuntime"	
-        command "reset"
+        command "stopMotion"
         
     }
 
@@ -56,7 +56,7 @@ metadata {
             }
         }
         valueTile("battery", "device.battery", decoration: "flat", inactiveLabel: false, width: 2, height: 2) {
-            state "default", label:'${currentValue}%', unit:"",
+            state "default", label:'${currentValue}%', unit:"%",
             backgroundColors: [
                 [value: 10, color: "#bc2323"],
                 [value: 26, color: "#f1d801"],
@@ -70,7 +70,7 @@ metadata {
 	    state "default", label:''
         }
         standardTile("reset", "device.reset", inactiveLabel: false, decoration: "flat", width: 2, height: 2) {
-            state "default", action:"reset", label: "Reset Motion", icon:"st.motion.motion.active"
+            state "default", action:"stopMotion", label: "Reset Motion", icon:"st.motion.motion.active"
         }
         valueTile("lastcheckin", "device.lastCheckin", decoration: "flat", inactiveLabel: false, width: 4, height: 1) {
             state "default", label:'Last Event:\n ${currentValue}'
@@ -81,18 +81,20 @@ metadata {
         main(["motion"])
         details(["motion", "spacer2", "battery", "reset", "spacer2", "spacer2", "lastcheckin", "spacer2", "spacer2", "batteryRuntime", "spacer2"])
    }
+
    preferences {
-		//motion Time out
-	        input name: "motionReset", "number", title: "Number of seconds after the last reported activity to report that motion is inactive (in seconds). \n\n(The device will always remain blind to motion for 60seconds following first detected motion. This value just clears the 'active' status after the number of seconds you set here but the device will still remain blind for 60seconds in normal operation.)", description: "", defaultValue:120
+		//Reset to No Motion Config
+		input description: "This setting only changes how long MOTION DETECTED is reported in SmartThings. The sensor hardware always remains blind to motion for 60 seconds after any activity.", type: "paragraph", element: "paragraph", title: "MOTION RESET"
+		input "motionreset", "number", title: "", description: "Enter number of seconds (default = 60)", range: "1..7200"
 		//Date & Time Config
 		input description: "", type: "paragraph", element: "paragraph", title: "DATE & CLOCK"    
 		input name: "dateformat", type: "enum", title: "Set Date Format\n US (MDY) - UK (DMY) - Other (YMD)", description: "Date Format", options:["US","UK","Other"]
 		input name: "clockformat", type: "bool", title: "Use 24 hour clock?"
 		//Battery Reset Config
-            	input description: "If you have installed a new battery, the toggle below will reset the Changed Battery date to help remember when it was changed.", type: "paragraph", element: "paragraph", title: "CHANGED BATTERY DATE RESET"
+		input description: "If you have installed a new battery, the toggle below will reset the Changed Battery date to help remember when it was changed.", type: "paragraph", element: "paragraph", title: "CHANGED BATTERY DATE RESET"
 		input name: "battReset", type: "bool", title: "Battery Changed?"
 		//Battery Voltage Offset
-	        input description: "Only change the settings below if you know what you're doing.", type: "paragraph", element: "paragraph", title: "ADVANCED SETTINGS"
+		input description: "Only change the settings below if you know what you're doing.", type: "paragraph", element: "paragraph", title: "ADVANCED SETTINGS"
 		input name: "voltsmax", title: "Max Volts\nA battery is at 100% at __ volts\nRange 2.8 to 3.4", type: "decimal", range: "2.8..3.4", defaultValue: 3, required: false
 		input name: "voltsmin", title: "Min Volts\nA battery is at 0% (needs replacing) at __ volts\nRange 2.0 to 2.7", type: "decimal", range: "2..2.7", defaultValue: 2.5, required: false
   }
@@ -100,12 +102,13 @@ metadata {
 
 // Parse incoming device messages to generate events
 def parse(String description) {
-    log.debug "${device.displayName} Parsing: $description"
+	log.debug "${device.displayName} Parsing: $description"
 	
 	// Determine current time and date in the user-selected date format and clock style
 	def now = formatDate()    
 	def nowDate = new Date(now).getTime()
-	// Any report - motion, lux & Battery - results in a lastCheckin event and update to Last Checkin tile
+
+	// Any report - motion, lux & Battery - results in a lastCheckin event and update to Last Event tile
 	// However, only a non-parseable report results in lastCheckin being displayed in events log
 	sendEvent(name: "lastCheckin", value: now, displayed: false)
 	sendEvent(name: "lastCheckinDate", value: nowDate, displayed: false)
@@ -113,17 +116,72 @@ def parse(String description) {
 	Map map = [:]
 
 	// Send message data to appropriate parsing function based on the type of report	
-	if (description?.startsWith('catchall:')) {
-		map = parseCatchAllMessage(description)
-	}
-	else if (description?.startsWith('read attr -')) {
+	if (description?.startsWith('read attr -')) {
 		map = parseReportAttributeMessage(description)
+	}
+	else if (description?.startsWith('catchall:')) {
+		map = parseCatchAllMessage(description)
 	}
  
 	log.debug "${device.displayName} Parse returned: $map"
 	def result = map ? createEvent(map) : null
 
 	return result
+}
+
+// Parse motion active report or model name message on reset button press
+private Map parseReportAttributeMessage(String description) {
+	def cluster = description.split(",").find {it.split(":")[0].trim() == "cluster"}?.split(":")[1].trim()
+	def attrId = description.split(",").find {it.split(":")[0].trim() == "attrId"}?.split(":")[1].trim()
+	def value = description.split(",").find {it.split(":")[0].trim() == "value"}?.split(":")[1].trim()
+ 
+	Map resultMap = [:]
+	def now = formatDate()
+
+	// The sensor only sends a motion detected message so the reset to no motion is performed in code
+	if (cluster == "0406" & value == "01") {
+		log.debug "${device.displayName} detected motion"
+		def seconds = motionreset ? motionreset : 60
+		resultMap = [
+			name: 'motion',
+			value: 'active',
+			descriptionText: "${device.displayName} detected motion"
+		]
+		sendEvent(name: "lastMotion", value: now, displayed: false)
+		runIn(seconds, stopMotion)
+	} 
+	else if (cluster == "0000" && attrId == "0005") {
+		def modelName = ""
+		// Parsing the model
+		for (int i = 0; i < value.length(); i+=2) {
+			def str = value.substring(i, i+2);
+			def NextChar = (char)Integer.parseInt(str, 16);
+			modelName = modelName + NextChar
+		}
+		log.debug "${device.displayName} reported: cluster: ${cluster}, attrId: ${attrId}, model:${modelName}"
+	}
+	return resultMap
+}
+
+// Check catchall for battery voltage data to pass to getBatteryResult for conversion to percentage report
+private Map parseCatchAllMessage(String description) {
+	Map resultMap = [:]
+	def catchall = zigbee.parse(description)
+    def i
+	log.debug catchall
+	if  (catchall.clusterId == 0x0000) {
+		def MsgLength = catchall.data.size();
+		// Xiaomi Aqara CatchAll does not have identifiers, first UINT16 is Battery
+		if ((catchall.data.get(0) == 0x02) && (catchall.data.get(1) == 0xFF)) {
+			for (i = 0; i < (MsgLength-3); i++) {
+				if (catchall.data.get(i) == 0x21) { // check the data ID and data type
+					// next two bytes are the battery voltage
+					resultMap = getBatteryResult((catchall.data.get(i+2)<<8) + catchall.data.get(i+1))
+				}
+			}
+		}
+	}
+	return resultMap
 }
 
 // Convert raw 4 digit integer voltage value into percentage based on minVolts/maxVolts range
@@ -134,12 +192,12 @@ private Map getBatteryResult(rawValue) {
     def minVolts
     def maxVolts
 
-    if(voltsmin == null || voltsmin == "")
+    if (voltsmin == null || voltsmin == "")
     	minVolts = 2.5
     else
    	minVolts = voltsmin
     
-    if(voltsmax == null || voltsmax == "")
+    if (voltsmax == null || voltsmax == "")
     	maxVolts = 3.0
     else
 	maxVolts = voltsmax
@@ -151,158 +209,20 @@ private Map getBatteryResult(rawValue) {
         name: 'battery',
         value: roundedPct,
         unit: "%",
-        isStateChange:true,
-        descriptionText : "${device.displayName} raw battery is ${rawVolts}v"
+        isStateChange: true,
+        descriptionText: "${device.displayName} raw battery is ${rawVolts}v"
     ]
-    
-    log.debug "${device.displayName}: ${result}"
+
     return result
 }
 
-// Check catchall for battery voltage data to pass to getBatteryResult for conversion to percentage report
-private Map parseCatchAllMessage(String description) {
-	Map resultMap = [:]
-	def cluster = zigbee.parse(description)
-    def i
-	log.debug cluster
-	if (shouldProcessMessage(cluster)) {
-		switch(cluster.clusterId) {
-			case 0x0000:
-                def MsgLength = cluster.data.size();
-                for (i = 0; i < (MsgLength-3); i++)
-                {
-                    // Original Xiaomi CatchAll does not have identifiers, first UINT16 is Battery
-                    if ((cluster.data.get(0) == 0x02) && (cluster.data.get(1) == 0xFF))
-                    {
-                        if (cluster.data.get(i) == 0x21) // check the data ID and data type
-                        {
-                            // next two bytes are the battery voltage.
-                            resultMap = getBatteryResult((cluster.data.get(i+2)<<8) + cluster.data.get(i+1))
-                            return resultMap
-                        }
-                    }
-                }
-            	break
-
-			case 0x0402:
-				log.debug '${device.displayName}: TEMP'
-				// temp is last 2 data values. reverse to swap endian
-				String temp = cluster.data[-2..-1].reverse().collect { cluster.hex1(it) }.join()
-				def value = getTemperature(temp)
-				resultMap = getTemperatureResult(value)
-				break
-		}
-	}
-
-	return resultMap
-}
-
-private boolean shouldProcessMessage(cluster) {
-	// 0x0B is default response indicating message got through
-	// 0x07 is bind message
-	boolean ignoredMessage = cluster.profileId != 0x0104 ||
-	cluster.command == 0x0B ||
-	cluster.command == 0x07 ||
-	(cluster.data.size() > 0 && cluster.data.first() == 0x3e)
-	return !ignoredMessage
-}
-
-
-private Map parseReportAttributeMessage(String description) {
-	Map descMap = (description - "read attr - ").split(",").inject([:]) { map, param ->
-		def nameAndValue = param.split(":")
-		map += [(nameAndValue[0].trim()):nameAndValue[1].trim()]
-	}
-	//log.debug "Desc Map: $descMap"
- 
-	Map resultMap = [:]
-        def now = new Date().format("EEE MMM dd yyyy h:mm:ss a", location.timeZone)
-   
-	if (descMap.cluster == "0001" && descMap.attrId == "0020") {
-		resultMap = getBatteryResult(Integer.parseInt(descMap.value, 16))
-	}
-    else if (descMap.cluster == "0406" && descMap.attrId == "0000") {
-    	def value = descMap.value.endsWith("01") ? "active" : "inactive"
-	    sendEvent(name: "lastMotion", value: now)
-        if (settings.motionReset == null || settings.motionReset == "" ) settings.motionReset = 120
-        if (value == "active") runIn(settings.motionReset, stopMotion)
-    	resultMap = getMotionResult(value)
-    } 
-    else if (descMap.cluster == "0000" && descMap.attrId == "0005") 
-    {
-        def result = [
-			name: 'Model',
-			value: ''
-		]
-        for (int i = 0; i < descMap.value.length(); i+=2) 
-        {
-            def str = descMap.value.substring(i, i+2);
-            def NextChar = (char)Integer.parseInt(str, 16);
-            result.value = result.value + NextChar
-        }
-        resultMap = result
-    }
-	return resultMap
-}
- 
-private Map parseIasMessage(String description) {
-    List parsedMsg = description.split(' ')
-    String msgCode = parsedMsg[2]
-    
-    Map resultMap = [:]
-    switch(msgCode) {
-        case '0x0020': // Closed/No Motion/Dry
-        	resultMap = getMotionResult('inactive')
-            break
-
-        case '0x0021': // Open/Motion/Wet
-        	resultMap = getMotionResult('active')
-            break
-
-        case '0x0022': // Tamper Alarm
-        	log.debug '${device.displayName}: motion with tamper alarm'
-        	resultMap = getMotionResult('active')
-            break
-
-        case '0x0023': // Battery Alarm
-            break
-
-        case '0x0024': // Supervision Report
-        	log.debug '${device.displayName}: no motion with tamper alarm'
-        	resultMap = getMotionResult('inactive')
-            break
-
-        case '0x0025': // Restore Report
-            break
-
-        case '0x0026': // Trouble/Failure
-        	log.debug '${device.displayName}: motion with failure alarm'
-        	resultMap = getMotionResult('active')
-            break
-
-        case '0x0028': // Test Mode
-            break
-    }
-    return resultMap
-}
-
-private Map getMotionResult(value) {
-    //log.debug "${device.displayName}: motion"
-	String descriptionText = value == 'active' ? "${device.displayName} detected motion" : "${device.displayName} motion has stopped"
-	def commands = [
-		name: 'motion',
-		value: value,
-		descriptionText: descriptionText
-	] 
-    return commands
-}
-
+// If currently in 'active' motion detected state, stopMotion() resets to 'inactive' state and displays 'no motion'
 def stopMotion() {
-   sendEvent(name:"motion", value:"inactive")
-}
-
-def reset() {
-	sendEvent(name:"motion", value:"inactive")
+	if (device.currentState('motion')?.value == "active") {
+		def seconds = motionreset ? motionreset : 7
+		sendEvent(name:"motion", value:"inactive", isStateChange: true)
+		log.debug "${device.displayName} reset to no motion after ${seconds}"
+	}
 }
 
 def resetBatteryRuntime() {
@@ -313,12 +233,15 @@ def resetBatteryRuntime() {
 def configure() {
     log.debug "${device.displayName}: configuring"
     state.battery = 0
-    checkIntervalEvent("configure");
+    checkIntervalEvent("configured");
+    return
 }
 
+// installed() runs just after a sensor is paired using the "Add a Thing" method in the SmartThings mobile app
 def installed() {
     state.battery = 0
     resetBatteryRuntime()
+    log.debug "${device.displayName}: Setting Battery Changed to current date for newly paired sensor"
     checkIntervalEvent("installed");
 }
 

--- a/devicetypes/bspranger/xiaomi-motion-sensor.src/xiaomi-motion-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-motion-sensor.src/xiaomi-motion-sensor.groovy
@@ -219,7 +219,7 @@ private Map getBatteryResult(rawValue) {
 // If currently in 'active' motion detected state, stopMotion() resets to 'inactive' state and displays 'no motion'
 def stopMotion() {
 	if (device.currentState('motion')?.value == "active") {
-		def seconds = motionreset ? motionreset : 7
+		def seconds = motionreset ? motionreset : 60
 		sendEvent(name:"motion", value:"inactive", isStateChange: true)
 		log.debug "${device.displayName} reset to no motion after ${seconds}"
 	}


### PR DESCRIPTION
I have gone through all of the Aqara Motion Detector DTH code, and after removing unnecessary function calls and lines of code, removing error-prone code, and looking at the motion reset preference issue, ~~I have discovered that **this device is capable of continuous motion detection**!~~ I have fixed the issue with the motion reset setting being ignored, and got the DTH working as it should.

I am still using the `runIn()` scheduler to reset back to the 'no motion' / `inactivity` state that was already in the code, because in my testing it seems to work just fine. The default is now 60, the same as the hardware's motion detection reset time, but it is set in the code rather than by adding `default: 60` to the preference line.

I am extremely happy with how the code is working, but I really want some others to test it to see how it works for them.

I also need to go through the "original" motion detector code to clean it up as well.

Note that I created this Pull Request commit off of @tmleafs Standardization branch, so it should be merged first and this one afterward.