### PR TITLE
Add Testing Mode and ignoreMotion function

### DIFF
--- a/devicetypes/bspranger/xiaomi-aqara-motion-sensor.src/xiaomi-aqara-motion-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-motion-sensor.src/xiaomi-aqara-motion-sensor.groovy
@@ -265,7 +265,6 @@ def stopMotion() {
 def stopIgnoreMotion() {
 	state.ignoreMotion = false
 	log.debug "${device.displayName}: Finished ignoring motion detected messages"
-	}
 }
 
 //Reset the date displayed in Battery Changed tile to current date

--- a/devicetypes/bspranger/xiaomi-aqara-motion-sensor.src/xiaomi-aqara-motion-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-motion-sensor.src/xiaomi-aqara-motion-sensor.groovy
@@ -314,7 +314,7 @@ def updated() {
     stopMotion()
 	if (testMode) {
 		if (!state.testModeActive) {
-			runIn(30, finishTestMode)
+			runIn(120, finishTestMode)
 			state.testModeActive = true
 			log.debug "${device.displayName}: Testing Mode activated for 60 minutes"
 		} else

--- a/devicetypes/bspranger/xiaomi-aqara-motion-sensor.src/xiaomi-aqara-motion-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-motion-sensor.src/xiaomi-aqara-motion-sensor.groovy
@@ -1,6 +1,6 @@
 /**
  *  Xiaomi Aqara Motion Sensor
- *  Version 1.1
+ *  Version 1.2
  *
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except


### PR DESCRIPTION
As explained in [my post on the SmartThings forum](https://community.smartthings.com/t/original-aqara-xiaomi-zigbee-sensors-contact-temp-motion-button-outlet-leak-etc/113253/705), I've added a second countdown timer so that all motion detected messages are ignored for a period of 5 seconds less than the motion reset timer. The state of ignore or not is tracked by a "global" state object, `state.ignoreMotion`.

This avoids issues with automations being activated every 5-6 seconds when the sensor is put into "testing mode."

I have also changed the default motion reset preference setting to 61 seconds, so that the motion reset counter can be extended another 60 seconds if the sensor detects movement right after its hardware "blind" period finishes.

I removed `state.battery = 0` from installed() and configure() because it's not used at all, and added `state.ignoreMotion == false` to those calls as well as `updated()` to ensure the DTH pairs the sensor or saves preference settings with motion detected messages NOT being ignored.