### PR TITLE
Updated round button DTH with Held

### DIFF
--- a/devicetypes/bspranger/xiaomi-button.src/xiaomi-button.groovy
+++ b/devicetypes/bspranger/xiaomi-button.src/xiaomi-button.groovy
@@ -1,111 +1,100 @@
 /**
- *  Xiaomi Zigbee Button
- *  Version 1.1
+ *	Xiaomi Zigbee Button
+ *	Version 1.2
  *
  *
- *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License. You may obtain a copy of the License at:
+ *	Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ *	in compliance with the License. You may obtain a copy of the License at:
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *			http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
- *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
- *  for the specific language governing permissions and limitations under the License.
+ *	Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
+ *	on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ *	for the specific language governing permissions and limitations under the License.
  *
- *  Original device handler code by a4refillpad, adapted for use with Aqara model by bspranger
- *  Additional contributions to code by alecm, alixjg, bspranger, gn0st1c, foz333, jmagnuson, rinkek, ronvandegraaf, snalee, tmleafs, twonk, & veeceeoh 
- * 
- *  Known issues:
- *  Xiaomi sensors do not seem to respond to refresh requests
- *  Inconsistent rendering of user interface text/graphics between iOS and Android devices - This is due to SmartThings, not this device handler
- *  Pairing Xiaomi sensors can be difficult as they were not designed to use with a SmartThings hub. See 
+ *	Original device handler code by a4refillpad, adapted for use with Aqara model by bspranger
+ *	Additional contributions to code by alecm, alixjg, bspranger, gn0st1c, foz333, jmagnuson, rinkek, ronvandegraaf, snalee, tmleafs, twonk, & veeceeoh
  *
- *  Fingerprint Endpoint data:
- *  zbjoin: {"dni":"xxxx","d":"xxxxxxxxxxx","capabilities":"80","endpoints":[{"simple":"01 0104 5F01 01 03 0000 FFFF 0006 03 0000 0004 FFFF","application":"03","manufacturer":"LUMI","model":"lumi.sensor_switch.aq2"}],"parent":"0000","joinType":1}
- *     endpoints data
- *        01 - endpoint id
- *        0104 - profile id
- *        5F01 - device id
- *        01 - ignored
- *        03 - number of in clusters
- *        0000 ffff 0006 - inClusters
- *        03 - number of out clusters
- *        0000 0004 ffff - outClusters
- *        manufacturer "LUMI" - must match manufacturer field in fingerprint
- *        model "lumi.sensor_switch.aq2" - must match model in fingerprint
- *        deviceJoinName: whatever you want it to show in the app as a Thing
+ *	Known issues:
+ *	Xiaomi sensors do not seem to respond to refresh requests
+ *	Inconsistent rendering of user interface text/graphics between iOS and Android devices - This is due to SmartThings, not this device handler
+ *	Pairing Xiaomi sensors can be difficult as they were not designed to use with a SmartThings hub.
+ *
  *
  */
 
 metadata {
-    definition (name: "Xiaomi Button", namespace: "bspranger", author: "bspranger") {
-        capability "Battery"
-        capability "Button"
-        capability "Configuration"
-        capability "Sensor"
-	capability "Health Check"
-        capability "Momentary"
-        
-        attribute "lastCheckin", "string"
-        attribute "lastCheckinDate", "Date"
-        attribute "lastpressed", "string"
-        attribute "lastpressedDate", "string"
-        attribute "batterylevel", "string"
-        attribute "batteryRuntime", "String"
+		definition (name: "Xiaomi Button", namespace: "bspranger", author: "bspranger") {
+				capability "Battery"
+				capability "Sensor"
+				capability "Button"
+				capability "Actuator"
+				capability "Momentary"
+				capability "Configuration"
+				capability "Health Check"
 
-        fingerprint endpointId: "01", profileId: "0104", deviceId: "0104", inClusters: "0000,0003,FFFF,0019", outClusters: "0000,0004,0003,0006,0008,0005,0019", manufacturer: "LUMI", model: "lumi.sensor_switch", deviceJoinName: "Original Xiaomi Button"
+				attribute "lastCheckin", "string"
+				attribute "lastCheckinDate", "Date"
+				attribute "lastPressed", "string"
+				attribute "lastPressedDate", "string"
+				attribute "lastReleased", "string"
+				attribute "lastReleasedDate", "string"
+				attribute "batteryRuntime", "string"
 
-        command "resetBatteryRuntime"
+				fingerprint endpointId: "01", profileId: "0104", deviceId: "0104", inClusters: "0000,0003,FFFF,0019", outClusters: "0000,0004,0003,0006,0008,0005,0019", manufacturer: "LUMI", model: "lumi.sensor_switch", deviceJoinName: "Original Xiaomi Button"
+
+				command "resetBatteryRuntime"
 }
-    
-    simulator {
-          status "button 1 pressed": "on/off: 0"
-          status "button 1 released": "on/off: 1"
-    }
-    
-    tiles(scale: 2) {
 
-        multiAttributeTile(name:"button", type: "lighting", width: 6, height: 4, canChangeIcon: true) {
+		simulator {
+					status "Pressed": "on/off: 0"
+					status "Released": "on/off: 1"
+		}
+
+		tiles(scale: 2) {
+
+				multiAttributeTile(name:"button", type: "lighting", width: 6, height: 4, canChangeIcon: true) {
 			tileAttribute ("device.button", key: "PRIMARY_CONTROL") {
-                   attributeState("pushed", label:'Push', action: "momentary.push", backgroundColor:"#00a0dc")
-                attributeState("released", label:'Push', action: "momentary.push", backgroundColor:"#ffffff", nextState: "pushed")
-             }
-            tileAttribute("device.lastpressed", key: "SECONDARY_CONTROL") {
-                attributeState "default", label:'Last Pressed: ${currentValue}'
-            }
-        }        
-        valueTile("battery", "device.battery", decoration: "flat", inactiveLabel: false, width: 2, height: 2) {
-            state "battery", label:'${currentValue}%', unit:"%", icon:"https://raw.githubusercontent.com/bspranger/Xiaomi/master/images/XiaomiBattery.png",
+									 attributeState("pushed", label:'Push', action: "momentary.push", backgroundColor:"#00a0dc")
+								attributeState("released", label:'Push', action: "momentary.push", backgroundColor:"#ffffff", nextState: "pushed")
+						 }
+						tileAttribute("device.lastpressed", key: "SECONDARY_CONTROL") {
+								attributeState "default", label:'Last Pressed: ${currentValue}'
+						}
+				}
+				valueTile("battery", "device.battery", decoration: "flat", inactiveLabel: false, width: 2, height: 2) {
+						state "battery", label:'${currentValue}%', unit:"%", icon:"https://raw.githubusercontent.com/bspranger/Xiaomi/master/images/XiaomiBattery.png",
 			backgroundColors:[
-                [value: 10, color: "#bc2323"],
-                [value: 26, color: "#f1d801"],
-                [value: 51, color: "#44b621"]
+								[value: 10, color: "#bc2323"],
+								[value: 26, color: "#f1d801"],
+								[value: 51, color: "#44b621"]
 			]
-        }
-        valueTile("lastcheckin", "device.lastCheckin", decoration: "flat", inactiveLabel: false, width: 4, height: 1) {
-            state "default", label:'Last Event:\n${currentValue}'
-        }
+				}
+				valueTile("lastcheckin", "device.lastCheckin", decoration: "flat", inactiveLabel: false, width: 4, height: 1) {
+						state "default", label:'Last Event:\n${currentValue}'
+				}
 	valueTile("batteryRuntime", "device.batteryRuntime", inactiveLabel: false, decoration: "flat", width: 4, height: 1) {
-	    state "batteryRuntime", label:'Battery Changed: ${currentValue}'
-	}  	    
-        main (["button"])
-        details(["button","battery","lastcheckin","batteryRuntime"])
-   }
-   preferences {
+			state "batteryRuntime", label:'Battery Changed: ${currentValue}'
+	}
+				main (["button"])
+				details(["button","battery","lastcheckin","batteryRuntime"])
+	 }
+	 preferences {
 		//Button Config
-        	input name: "PressType", type: "enum", options: ["Momentary", "Toggle"], title: "Momentary or toggle? ", defaultValue: "Momentary"
+		input name: "PressType", type: "enum", options: ["Momentary", "Toggle"], title: "Momentary or Toggle mode? ", defaultValue: "Momentary"
+		input "waittoHeld", "number", title: "If the button is held, wait how many seconds until sending a 'held' message?", description: "Enter number of seconds (default = 3)"
 		//Date & Time Config
-		input description: "", type: "paragraph", element: "paragraph", title: "DATE & CLOCK"    
+		input description: "", type: "paragraph", element: "paragraph", title: "DATE & CLOCK"
 		input name: "dateformat", type: "enum", title: "Set Date Format\n US (MDY) - UK (DMY) - Other (YMD)", description: "Date Format", options:["US","UK","Other"]
 		input name: "clockformat", type: "bool", title: "Use 24 hour clock?"
 		//Battery Reset Config
-            	input description: "If you have installed a new battery, the toggle below will reset the Changed Battery date to help remember when it was changed.", type: "paragraph", element: "paragraph", title: "CHANGED BATTERY DATE RESET"
+		input description: "If you have installed a new battery, the toggle below will reset the Changed Battery date to help remember when it was changed.", type: "paragraph", element: "paragraph", title: "CHANGED BATTERY DATE RESET"
 		input name: "battReset", type: "bool", title: "Battery Changed?"
 		//Battery Voltage Offset
-            	input description: "Only change the settings below if you know what you're doing.", type: "paragraph", element: "paragraph", title: "ADVANCED SETTINGS"
+		input description: "Only change the settings below if you know what you're doing.", type: "paragraph", element: "paragraph", title: "ADVANCED SETTINGS"
 		input name: "voltsmax", title: "Max Volts\nA battery is at 100% at __ volts\nRange 2.8 to 3.4", type: "decimal", range: "2.8..3.4", defaultValue: 3, required: false
 		input name: "voltsmin", title: "Min Volts\nA battery is at 0% (needs replacing) at __ volts\nRange 2.0 to 2.7", type: "decimal", range: "2..2.7", defaultValue: 2.5, required: false
-    }
+		}
 }
 
 //adds functionality to press the centre tile as a virtualApp Button
@@ -113,80 +102,125 @@ def push() {
 	log.debug "Virtual App Button Pressed"
 	def now = formatDate()
 	def nowDate = new Date(now).getTime()
-        sendEvent(name: "lastpressed", value: now, displayed: false)
-        sendEvent(name: "lastpressedDate", value: nowDate, displayed: false) 
+	sendEvent(name: "lastPressed", value: now, displayed: false)
+	sendEvent(name: "lastPressedDate", value: nowDate, displayed: false)
 	sendEvent(name: "button", value: "pushed", data: [buttonNumber: 1], descriptionText: "$device.displayName app button was pushed", isStateChange: true)
+	sendEvent(name: "lastReleased", value: now, displayed: false)
+	sendEvent(name: "lastReleasedDate", value: nowDate, displayed: false)
 	sendEvent(name: "button", value: "released", data: [buttonNumber: 1], descriptionText: "$device.displayName app button was released", isStateChange: true)
 }
 
 // Parse incoming device messages to generate events
 def parse(String description) {
-    log.debug "${device.displayName}: Parsing '${description}'"
+	log.debug "${device.displayName}: Parsing '${description}'"
+	def result = [:]
 
-	// Determine current time and date in the user-selected date format and clock style 
-    def now = formatDate()	
-    def nowDate = new Date(now).getTime()
+	// Determine current time and date in the user-selected date format and clock style
+	def now = formatDate()
+	def nowDate = new Date(now).getTime()
 	// Any report - button press & Battery - results in a lastCheckin event and update to Last Checkin tile
 	// However, only a non-parseable report results in lastCheckin being displayed in events log
-    sendEvent(name: "lastCheckin", value: now, displayed: false)
-    sendEvent(name: "lastCheckinDate", value: nowDate, displayed: false) 
-
-    Map map = [:]
+	sendEvent(name: "lastCheckin", value: now, displayed: false)
+	sendEvent(name: "lastCheckinDate", value: nowDate, displayed: false)
 
 	// Send message data to appropriate parsing function based on the type of report
-    if (description?.startsWith('on/off: ')) 
-    {
-        map = parseCustomMessage(description) 
-        sendEvent(name: "lastpressed", value: now, displayed: false)
-        sendEvent(name: "lastpressedDate", value: nowDate, displayed: false) 
-    }
-    else if (description?.startsWith('catchall:')) 
-    {
-        map = parseCatchAllMessage(description)
-    }
-    else if (description?.startsWith("read attr - raw: "))
-    {
-        map = parseReadAttrMessage(description)  
-    }
-    log.debug "${device.displayName}: Parse returned $map"
-    def results = map ? createEvent(map) : null
+	if (description?.startsWith('on/off: ')) {
+		result = parseButtonMessage(description)
+	} else if (description?.startsWith('catchall:')) {
+		result = parseCatchAllMessage(description)
+	} else if (description?.startsWith("read attr - raw: ")) {
+		result = parseReadAttrMessage(description)
+	}
+	log.debug "${device.displayName}: Parse returned $map"
+	return createEvent(result)
+}
 
-    return results;
+private parseButtonMessage(description) {
+	def result = [:]
+	def onOff = (description - "on/off: ")
+	def now = formatDate()
+	def nowDate = new Date(now).getTime()
+
+	// in toggle mode only toggle when button is pressed
+	if (PressType == "Toggle") {
+		if (onOff == '0') {
+			if (device.currentValue('button') != "pushed")
+				result = getContactResult("pushed")
+			else
+				result = getContactResult("released")
+		}
+	}
+	// momentary mode
+	else {
+		if (onOff == '0') {
+			// on button pressed update lastPressed to current date/time
+			log.debug "${device.displayName}: Button pressed, setting Last Pressed to current date/time"
+			sendEvent(name: "lastPressed", value: now, displayed: false)
+			sendEvent(name: "lastPressedDate", value: nowDate, displayed: false)
+		} else
+			// on button released created buttton pushed or held event based on held timer
+			log.debug "${device.displayName}: Button released, setting Last Released to current date/time"
+			sendEvent(name: "lastReleased", value: now, displayed: false)
+			sendEvent(name: "lastReleasedDate", value: nowDate, displayed: false)
+			result = createButtonEvent()
+	}
+	return result
+}
+
+private createButtonEvent() {
+	def timeDif = now() - device.latestState('lastPressed').date.getTime()
+	def holdTimeMillisec = (settings.waittoHeld?:3).toInteger() * 1000
+	def value = "held"
+
+	// compare waittoHeld setting with difference between current time and lastPressed 
+	log.debug "${device.displayName}: Comparing time difference between this button release and Last Pressed"
+	if (timeDif < 0)
+		return [:]	// If there is an issue with message sequence do not parse this button release
+	else if (timeDif < holdTimeMillisec) 
+		value = "pushed"
+        
+	return [
+		name: 'button',
+		value: value,
+		data: [buttonNumber: "1"],
+		descriptionText: "${device.displayName} was ${value}",
+		isStateChange: true
+	]
 }
 
 private Map parseReadAttrMessage(String description) {
-    def buttonRaw = (description - "read attr - raw:")
-    Map resultMap = [:]
+	def buttonRaw = (description - "read attr - raw:")
+	Map resultMap = [:]
 
-    def cluster = description.split(",").find {it.split(":")[0].trim() == "cluster"}?.split(":")[1].trim()
-    def attrId = description.split(",").find {it.split(":")[0].trim() == "attrId"}?.split(":")[1].trim()
-    def value = description.split(",").find {it.split(":")[0].trim() == "value"}?.split(":")[1].trim()
-    def model = value.split("01FF")[0]
-    def data = value.split("01FF")[1]
-    log.debug "cluster: ${cluster}, attrId: ${attrId}, value: ${value}, model:${model}, data:${data}"
-    
-    if (data[4..7] == "0121") {
-    	def BatteryVoltage = (Integer.parseInt((data[10..11] + data[8..9]),16))
-        resultMap = getBatteryResult(BatteryVoltage)
-        log.debug "${device.displayName}: Parse returned $resultMap"
-        createEvent(resultMap)
-    }
+	def cluster = description.split(",").find {it.split(":")[0].trim() == "cluster"}?.split(":")[1].trim()
+	def attrId = description.split(",").find {it.split(":")[0].trim() == "attrId"}?.split(":")[1].trim()
+	def value = description.split(",").find {it.split(":")[0].trim() == "value"}?.split(":")[1].trim()
+	def model = value.split("01FF")[0]
+	def data = value.split("01FF")[1]
+	log.debug "cluster: ${cluster}, attrId: ${attrId}, value: ${value}, model:${model}, data:${data}"
 
-    if (cluster == "0000" && attrId == "0005")  {
-        resultMap.name = 'Model'
-        resultMap.value = ""
-        resultMap.descriptionText = "device model"
-        // Parsing the model
-        for (int i = 0; i < model.length(); i+=2) 
-        {
-            def str = model.substring(i, i+2);
-            def NextChar = (char)Integer.parseInt(str, 16);
-            resultMap.value = resultMap.value + NextChar
-        }
-        return resultMap
-    }
-    
-    return [:]    
+	if (data[4..7] == "0121") {
+		def BatteryVoltage = (Integer.parseInt((data[10..11] + data[8..9]),16))
+			resultMap = getBatteryResult(BatteryVoltage)
+			log.debug "${device.displayName}: Parse returned $resultMap"
+			createEvent(resultMap)
+	}
+
+		if (cluster == "0000" && attrId == "0005")	{
+				resultMap.name = 'Model'
+				resultMap.value = ""
+				resultMap.descriptionText = "device model"
+				// Parsing the model
+				for (int i = 0; i < model.length(); i+=2)
+				{
+						def str = model.substring(i, i+2);
+						def NextChar = (char)Integer.parseInt(str, 16);
+						resultMap.value = resultMap.value + NextChar
+				}
+				return resultMap
+		}
+
+		return [:]
 }
 
 // Check catchall for battery voltage data to pass to getBatteryResult for conversion to percentage report
@@ -213,85 +247,23 @@ private Map parseCatchAllMessage(String description) {
 
 // Convert raw 4 digit integer voltage value into percentage based on minVolts/maxVolts range
 private Map getBatteryResult(rawValue) {
-    // raw voltage is normally supplied as a 4 digit integer that needs to be divided by 1000
-    // but in the case the final zero is dropped then divide by 100 to get actual voltage value 
-    def rawVolts = rawValue / 1000
-    def minVolts
-    def maxVolts
+	// raw voltage is normally supplied as a 4 digit integer that needs to be divided by 1000
+	// but in the case the final zero is dropped then divide by 100 to get actual voltage value
+	def rawVolts = rawValue / 1000
+	def minVolts = voltsmin ? voltsmin : 2.5
+	def maxVolts = voltsmax ? voltsmax : 3.0
+	def pct = (rawVolts - minVolts) / (maxVolts - minVolts)
+	def roundedPct = Math.min(100, Math.round(pct * 100))
+	def result = [
+		name: 'battery',
+		value: roundedPct,
+		unit: "%",
+		isStateChange:true,
+		descriptionText : "${device.displayName} Battery at ${roundedPct}% (${rawVolts} Volts)"
+	]
 
-    if(voltsmin == null || voltsmin == "")
-    	minVolts = 2.5
-    else
-   	minVolts = voltsmin
-    
-    if(voltsmax == null || voltsmax == "")
-    	maxVolts = 3.0
-    else
-	maxVolts = voltsmax
-	
-    def pct = (rawVolts - minVolts) / (maxVolts - minVolts)
-    def roundedPct = Math.min(100, Math.round(pct * 100))
-
-    def result = [
-        name: 'battery',
-        value: roundedPct,
-        unit: "%",
-        isStateChange:true,
-        descriptionText : "${device.displayName} Battery at ${roundedPct}% (${rawVolts} Volts)"
-    ]
-    
-    log.debug "${device.displayName}: ${result}"
-    return createEvent(result)
-}
-
-private Map parseCustomMessage(String description) {
-    def result = [:]
-    if (description?.startsWith('on/off: ')) 
-    {
-        if (PressType == "Toggle")
-        {
-            if ((state.button != "pushed") && (state.button != "released")) 
-            {
-                state.button = "released"
-            }
-            if (description == 'on/off: 0')
-            {
-                if (state.button == "released") 
-                {
-                   result = getContactResult("pushed")
-                   state.button = "pushed"
-                }
-                else 
-                {
-                   result = getContactResult("released")
-                   state.button = "released"
-                }
-            }
-        }
-        else
-        {
-            if (description == 'on/off: 0')
-            {
-                result = getContactResult("pushed")
-            } 
-            else if (description == 'on/off: 1')
-            {
-                result = getContactResult("released")
-            }
-        }
-        return result
-    }
-}
-
-private Map getContactResult(value) {
-    def descriptionText = "${device.displayName} was ${value == 'pushed' ? 'pushed' : 'released'}"
-    return [
-        name: 'button',
-        value: value,
-	data: [buttonNumber: "1"],
-        descriptionText: descriptionText,
-	isStateChange: true
-    ]
+	log.debug "${device.displayName}: ${result}"
+	return createEvent(result)
 }
 
 //Reset the date displayed in Battery Changed tile to current date
@@ -304,64 +276,65 @@ def resetBatteryRuntime(paired) {
 
 // installed() runs just after a sensor is paired using the "Add a Thing" method in the SmartThings mobile app
 def installed() {
-	state.battery = 0
-	if (!batteryRuntime) resetBatteryRuntime(true)
+	log.debug "${device.displayName}: Installing"
+	if (!batteryRuntime)
+		resetBatteryRuntime(true)
 	checkIntervalEvent("installed")
 }
 
 // configure() runs after installed() when a sensor is paired
 def configure() {
-	log.debug "${device.displayName}: configuring"
-		state.battery = 0
-	if (!batteryRuntime) resetBatteryRuntime(true)
+	log.debug "${device.displayName}: Configuring"
+	if (!batteryRuntime)
+		resetBatteryRuntime(true)
 	checkIntervalEvent("configured")
 	return
 }
 
 // updated() will run twice every time user presses save in preference settings page
 def updated() {
-		checkIntervalEvent("updated")
-		if(battReset){
+	checkIntervalEvent("updated")
+	if(battReset){
 		resetBatteryRuntime()
 		device.updateSetting("battReset", false)
 	}
 }
 
 private checkIntervalEvent(text) {
-    // Device wakes up every 1 hours, this interval allows us to miss one wakeup notification before marking offline
-    log.debug "${device.displayName}: Configured health checkInterval when ${text}()"
-    sendEvent(name: "checkInterval", value: 2 * 60 * 60 + 2 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
+		// Device wakes up every 1 hours, this interval allows us to miss one wakeup notification before marking offline
+		log.debug "${device.displayName}: Configured health checkInterval when ${text}()"
+		sendEvent(name: "checkInterval", value: 2 * 60 * 60 + 2 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
 }
 
 def formatDate(batteryReset) {
-    def correctedTimezone = ""
-    def timeString = clockformat ? "HH:mm:ss" : "h:mm:ss aa"
+	def correctedTimezone = ""
+	def timeString = clockformat ? "HH:mm:ss" : "h:mm:ss aa"
 
 	// If user's hub timezone is not set, display error messages in log and events log, and set timezone to GMT to avoid errors
-    if (!(location.timeZone)) {
-        correctedTimezone = TimeZone.getTimeZone("GMT")
-        log.error "${device.displayName}: Time Zone not set, so GMT was used. Please set up your location in the SmartThings mobile app."
-        sendEvent(name: "error", value: "", descriptionText: "ERROR: Time Zone not set, so GMT was used. Please set up your location in the SmartThings mobile app.")
-    } 
-    else {
-        correctedTimezone = location.timeZone
-    }
-    if (dateformat == "US" || dateformat == "" || dateformat == null) {
-        if (batteryReset)
-            return new Date().format("MMM dd yyyy", correctedTimezone)
-        else
-            return new Date().format("EEE MMM dd yyyy ${timeString}", correctedTimezone)
-    }
-    else if (dateformat == "UK") {
-        if (batteryReset)
-            return new Date().format("dd MMM yyyy", correctedTimezone)
-        else
-            return new Date().format("EEE dd MMM yyyy ${timeString}", correctedTimezone)
-        }
-    else {
-        if (batteryReset)
-            return new Date().format("yyyy MMM dd", correctedTimezone)
-        else
-            return new Date().format("EEE yyyy MMM dd ${timeString}", correctedTimezone)
-    }
+	if (!(location.timeZone)) {
+		correctedTimezone = TimeZone.getTimeZone("GMT")
+		log.error "${device.displayName}: Time Zone not set, so GMT was used. Please set up your location in the SmartThings mobile app."
+		sendEvent(name: "error", value: "", descriptionText: "ERROR: Time Zone not set, so GMT was used. Please set up your location in the SmartThings mobile app.")
+	}
+	else {
+		correctedTimezone = location.timeZone
+	}
+	if (dateformat == "US" || dateformat == "" || dateformat == null) {
+		if (batteryReset)
+			return new Date().format("MMM dd yyyy", correctedTimezone)
+		else
+			return new Date().format("EEE MMM dd yyyy ${timeString}", correctedTimezone)
+	}
+	else if (dateformat == "UK") {
+		if (batteryReset)
+			return new Date().format("dd MMM yyyy", correctedTimezone)
+		else
+			return new Date().format("EEE dd MMM yyyy ${timeString}", correctedTimezone)
+	}
+	else {
+		if (batteryReset)
+			return new Date().format("yyyy MMM dd", correctedTimezone)
+		else
+			return new Date().format("EEE yyyy MMM dd ${timeString}", correctedTimezone)
+	}
 }

--- a/devicetypes/bspranger/xiaomi-button.src/xiaomi-button.groovy
+++ b/devicetypes/bspranger/xiaomi-button.src/xiaomi-button.groovy
@@ -1,24 +1,24 @@
 /**
- *  Xiaomi Zigbee Button
- *  Version 1.2
+ *	Xiaomi Zigbee Button
+ *	Version 1.2
  *
  *
- *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License. You may obtain a copy of the License at:
+ *	Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ *	in compliance with the License. You may obtain a copy of the License at:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *	    http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
- *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
- *  for the specific language governing permissions and limitations under the License.
+ *	Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
+ *	on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ *	for the specific language governing permissions and limitations under the License.
  *
- *  Original device handler code by a4refillpad, adapted for use with Aqara model by bspranger
- *  Additional contributions to code by alecm, alixjg, bspranger, gn0st1c, foz333, jmagnuson, rinkek, ronvandegraaf, snalee, tmleafs, twonk, & veeceeoh
+ *	Original device handler code by a4refillpad, adapted for use with Aqara model by bspranger
+ *	Additional contributions to code by alecm, alixjg, bspranger, gn0st1c, foz333, jmagnuson, rinkek, ronvandegraaf, snalee, tmleafs, twonk, & veeceeoh
  *
- *  Known issues:
- *  Xiaomi sensors do not seem to respond to refresh requests
- *  Inconsistent rendering of user interface text/graphics between iOS and Android devices - This is due to SmartThings, not this device handler
- *  Pairing Xiaomi sensors can be difficult as they were not designed to use with a SmartThings hub.
+ *	Known issues:
+ *	Xiaomi sensors do not seem to respond to refresh requests
+ *	Inconsistent rendering of user interface text/graphics between iOS and Android devices - This is due to SmartThings, not this device handler
+ *	Pairing Xiaomi sensors can be difficult as they were not designed to use with a SmartThings hub.
  *
  *
  */
@@ -30,6 +30,7 @@ metadata {
 		capability "Button"
 		capability "Holdable Button"
 		capability "Actuator"
+		capability "Momentary"
 		capability "Configuration"
 		capability "Health Check"
 
@@ -48,18 +49,18 @@ metadata {
 	}
 
 	simulator {
-		status "Pressed": "on/off: 0"
-		status "Released": "on/off: 1"
+		status "Press button": "on/off: 0"
+		status "Release button": "on/off: 1"
 	}
 
 	tiles(scale: 2) {
 		multiAttributeTile(name:"button", type: "lighting", width: 6, height: 4, canChangeIcon: true) {
 			tileAttribute ("device.button", key: "PRIMARY_CONTROL") {
 				attributeState("pushed", label:'Pushed', action: "momentary.push", backgroundColor:"#00a0dc")
-				attributeState("held", label:'Held', action: "momentary.push", backgroundColor:"#00a0dc")
+				attributeState("held", label:'Held', backgroundColor:"#00a0dc")
 			}
-			tileAttribute("device.lastpressed", key: "SECONDARY_CONTROL") {
-				attributeState "default", label:'Last Pressed: ${currentValue}'
+			tileAttribute("device.lastPressed", key: "SECONDARY_CONTROL") {
+				attributeState "lastPressed", label:'Last Pressed: ${currentValue}'
 			}
 		}
 		valueTile("battery", "device.battery", decoration: "flat", inactiveLabel: false, width: 2, height: 2) {
@@ -82,14 +83,19 @@ metadata {
 
 	preferences {
 		//Button Config
+		input description: "", type: "paragraph", element: "paragraph", title: "BUTTON CONFIGURATION"
 		input name: "waittoHeld", type: "decimal", title: "If the button is held, wait how many seconds until sending a 'held' message?", description: "Number of seconds (default = 2.0)", range: "0.1..120"
 		//Date & Time Config
 		input description: "", type: "paragraph", element: "paragraph", title: "DATE & CLOCK"
-		input name: "dateformat", type: "enum", title: "Set Date Format\n US (MDY) - UK (DMY) - Other (YMD)", description: "Date Format", options:["US","UK","Other"]
+		input name: "dateformat", type: "enum", title: "Set Date Format\nUS (MDY) - UK (DMY) - Other (YMD)", description: "Date Format", options:["US","UK","Other"]
 		input name: "clockformat", type: "bool", title: "Use 24 hour clock?"
 		//Battery Reset Config
 		input description: "If you have installed a new battery, the toggle below will reset the Changed Battery date to help remember when it was changed.", type: "paragraph", element: "paragraph", title: "CHANGED BATTERY DATE RESET"
 		input name: "battReset", type: "bool", title: "Battery Changed?"
+		//Live Logging Message Display Config
+		input description: "These settings affect the display of messages in the Live Logging tab of the SmartThings IDE.", type: "paragraph", element: "paragraph", title: "LIVE LOGGING"
+		input name: "infoLogging", type: "bool", title: "Display info log messages?", defaultValue: true
+		input name: "debugLogging", type: "bool", title: "Display debug log messages?"
 		//Battery Voltage Offset
 		input description: "Only change the settings below if you know what you're doing.", type: "paragraph", element: "paragraph", title: "ADVANCED SETTINGS"
 		input name: "voltsmax", type: "decimal", title: "Max Volts\nA battery is at 100% at __ volts\nRange 2.8 to 3.4", range: "2.8..3.4", defaultValue: 3, required: false
@@ -99,7 +105,7 @@ metadata {
 
 //adds functionality to press the centre tile as a virtualApp Button
 def push() {
-	log.debug "Virtual App Button Pressed"
+	displayInfoLog(": Virtual App Button Pressed")
 	sendEvent(name: "lastPressed", value: formatDate(), displayed: false)
 	sendEvent(name: "lastPressedCoRE", value: now(), displayed: false)
 	sendEvent(name: "button", value: "pushed", data: [buttonNumber: 1], descriptionText: "$device.displayName app button was pushed", isStateChange: true)
@@ -109,7 +115,7 @@ def push() {
 
 // Parse incoming device messages to generate events
 def parse(String description) {
-	log.debug "${device.displayName}: Parsing '${description}'"
+	displayDebugLog(": Parsing '${description}'")
 	def result = [:]
 
 	// Any report - button press & Battery - results in a lastCheckin event and update to Last Checkin tile
@@ -124,8 +130,11 @@ def parse(String description) {
 	} else if (description?.startsWith("read attr - raw: ")) {
 		result = parseReadAttrMessage(description)
 	}
-	log.debug "${device.displayName}: Parse returned $result"
-	return createEvent(result)
+	if (result != [:]) {
+		displayDebugLog(": Creating event $result")
+		return createEvent(result)
+	} else
+		return [:]
 }
 
 private parseButtonMessage(description) {
@@ -134,13 +143,13 @@ private parseButtonMessage(description) {
 
 	if (onOff == '0') {
 		// on button pressed update lastPressed and lastButtonMssg to current date/time
-		log.debug "${device.displayName}: Button pressed, setting Last Pressed to current date/time"
+		displayDebugLog(": Button pressed, setting lastPressed to current date/time")
 		sendEvent(name: "lastPressed", value: formatDate(), displayed: false)
 		sendEvent(name: "lastPressedCoRE", value: now(), displayed: false)
 		sendEvent(name: "lastButtonMssg", value: now(), displayed: false)
 	} else if (onOff == '1') {
-		// on button released create map for buttton pushed or held event based on held time setting
-		log.debug "${device.displayName}: Button released, setting Last Released to current date/time"
+		// on button released create event map for buttton pushed or held and update lastPressed and lastButtonMssg to current date/time
+		displayDebugLog(": Button released, setting lastReleased to current date/time")
 		sendEvent(name: "lastReleased", value: formatDate(), displayed: false)
 		sendEvent(name: "lastReleasedCoRE", value: now(), displayed: false)
 		result = createButtonEvent()
@@ -154,14 +163,15 @@ private createButtonEvent() {
 	def holdTimeMillisec = Math.round((settings.waittoHeld?:2.0) * 1000)
 	def value = "held"
 
-	log.debug "${device.displayName}: Comparing time difference between this button release and last button message"
-	log.debug "${device.displayName}: Time difference = $timeDif ms, Hold time setting = $holdTimeMillisec"
+	displayDebugLog(": Comparing time difference between this button release and last button message")
+	displayDebugLog(": Time difference = $timeDif ms, Hold time setting = $holdTimeMillisec ms")
 	// If there is an issue with message sequence do not parse this button release
 	if (timeDif < 0)
 		return [:]
 	// compare waittoHeld setting with difference between current time and lastButtonMssg
-	else if (timeDif < holdTimeMillisec)
+	else if (timeDif < holdTimeMillisec || timeDif > holdTimeMillisec + 10000)
 		value = "pushed"
+	displayInfoLog(" was ${value}")
 
 	return [
 		name: 'button',
@@ -173,14 +183,14 @@ private createButtonEvent() {
 }
 
 private Map parseReadAttrMessage(String description) {
-
+	def buttonRaw = (description - "read attr - raw:")
 	Map resultMap = [:]
 
 	def cluster = description.split(",").find {it.split(":")[0].trim() == "cluster"}?.split(":")[1].trim()
 	def attrId = description.split(",").find {it.split(":")[0].trim() == "attrId"}?.split(":")[1].trim()
 	def value = description.split(",").find {it.split(":")[0].trim() == "value"}?.split(":")[1].trim()
-	def model = value.split("01FF")[0]
-	def data = value.split("01FF")[1]
+	def model = value.split("02FF")[0]
+	def data = value.split("02FF")[1]
 
 	if (data[4..7] == "0121") {
 		def BatteryVoltage = (Integer.parseInt((data[10..11] + data[8..9]),16))
@@ -195,7 +205,7 @@ private Map parseReadAttrMessage(String description) {
 			def NextChar = (char)Integer.parseInt(str, 16);
 			modelName = modelName + NextChar
 		}
-		log.debug "${device.displayName} reported: cluster: 0000, attrId: 0005, value: ${value}, model:${modelName}, data:${data}"
+		displayDebugLog(" reported: cluster: 0000, attrId: 0005, value: ${value}, model:${modelName}, data:${data}")
 	}
 
 	return resultMap
@@ -205,7 +215,6 @@ private Map parseReadAttrMessage(String description) {
 private Map parseCatchAllMessage(String description) {
 	Map resultMap = [:]
 	def catchall = zigbee.parse(description)
-	log.debug catchall
 
 	if (catchall.clusterId == 0x0000) {
 		def MsgLength = catchall.data.size()
@@ -232,26 +241,37 @@ private Map getBatteryResult(rawValue) {
 	def maxVolts = voltsmax ? voltsmax : 3.0
 	def pct = (rawVolts - minVolts) / (maxVolts - minVolts)
 	def roundedPct = Math.min(100, Math.round(pct * 100))
-	log.debug "${device.displayName}: ${result}"
+	def descText = "Battery at ${roundedPct}% (${rawVolts} Volts)"
+	displayInfoLog(": $descText")
 	return [
 		name: 'battery',
 		value: roundedPct,
 		unit: "%",
 		isStateChange:true,
-		descriptionText : "${device.displayName} Battery at ${roundedPct}% (${rawVolts} Volts)"
+		descriptionText : "$device.displayName $descText"
 	]
+}
+
+private def displayDebugLog(message) {
+	if (debugLogging)
+		log.debug "${device.displayName}${message}"
+}
+
+private def displayInfoLog(message) {
+	if (infoLogging)
+		log.info "${device.displayName}${message}"
 }
 
 //Reset the date displayed in Battery Changed tile to current date
 def resetBatteryRuntime(paired) {
 	def newlyPaired = paired ? " for newly paired sensor" : ""
 	sendEvent(name: "batteryRuntime", value: formatDate(true))
-	log.debug "${device.displayName}: Setting Battery Changed to current date${newlyPaired}"
+	displayInfoLog(": Setting Battery Changed to current date${newlyPaired}")
 }
 
 // installed() runs just after a sensor is paired using the "Add a Thing" method in the SmartThings mobile app
 def installed() {
-	log.debug "${device.displayName}: Installing"
+	displayInfoLog(": Installing")
 	if (!batteryRuntime)
 		resetBatteryRuntime(true)
 	checkIntervalEvent("installed")
@@ -259,7 +279,7 @@ def installed() {
 
 // configure() runs after installed() when a sensor is paired
 def configure() {
-	log.debug "${device.displayName}: Configuring"
+	displayInfoLog(": Configuring")
 	if (!batteryRuntime)
 		resetBatteryRuntime(true)
 	checkIntervalEvent("configured")
@@ -268,16 +288,19 @@ def configure() {
 
 // updated() will run twice every time user presses save in preference settings page
 def updated() {
-	checkIntervalEvent("updated")
-	if(battReset){
+	displayInfoLog(": Updating preference settings")
+	if (battReset){
 		resetBatteryRuntime()
 		device.updateSetting("battReset", false)
 	}
+	checkIntervalEvent("updated")
+	displayInfoLog(": Info message logging enabled")
+	displayDebugLog(": Debug message logging enabled")
 }
 
 private checkIntervalEvent(text) {
 		// Device wakes up every 1 hours, this interval allows us to miss one wakeup notification before marking offline
-		log.debug "${device.displayName}: Configured health checkInterval when ${text}()"
+		displayInfoLog(": Configured health checkInterval when ${text}")
 		sendEvent(name: "checkInterval", value: 2 * 60 * 60 + 2 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
 }
 

--- a/devicetypes/bspranger/xiaomi-button.src/xiaomi-button.groovy
+++ b/devicetypes/bspranger/xiaomi-button.src/xiaomi-button.groovy
@@ -56,10 +56,10 @@ metadata {
 	tiles(scale: 2) {
 		multiAttributeTile(name:"buttonStatus", type: "lighting", width: 6, height: 4, canChangeIcon: false) {
 			tileAttribute ("device.buttonStatus", key: "PRIMARY_CONTROL") {
-				attributeState("default", label:'Pushed', backgroundColor:"#00a0dc", icon:"https://raw.githubusercontent.com/veeceeoh/Xiaomi/master/images/button-pushed-icn.png")
-				attributeState("pushed", label:'Pushed', backgroundColor:"#00a0dc", icon:"https://raw.githubusercontent.com/veeceeoh/Xiaomi/master/images/button-pushed-icn.png")
-				attributeState("held", label:'Held', backgroundColor:"#00a0dc", icon:"https://raw.githubusercontent.com/veeceeoh/Xiaomi/master/images/button-pushed-icn.png")
-				attributeState("released", label:'Released', action: "momentary.push", backgroundColor:"#ffffff", icon:"https://raw.githubusercontent.com/veeceeoh/Xiaomi/master/images/button-released-icn.png")
+				attributeState("default", label:'Pushed', backgroundColor:"#00a0dc", icon:"https://raw.githubusercontent.com/bspranger/Xiaomi/master/images/ButtonPushed.png")
+				attributeState("pushed", label:'Pushed', backgroundColor:"#00a0dc", icon:"https://raw.githubusercontent.com/bspranger/Xiaomi/master/images/ButtonPushed.png")
+				attributeState("held", label:'Held', backgroundColor:"#00a0dc", icon:"https://raw.githubusercontent.com/bspranger/Xiaomi/master/images/ButtonPushed.png")
+				attributeState("released", label:'Released', action: "momentary.push", backgroundColor:"#ffffff", icon:"https://raw.githubusercontent.com/bspranger/Xiaomi/master/images/ButtonReleased.png")
 			}
 			tileAttribute("device.lastPressed", key: "SECONDARY_CONTROL") {
 				attributeState "lastPressed", label:'Last Pressed: ${currentValue}'
@@ -85,7 +85,7 @@ metadata {
 
 	preferences {
 		//Button Config
-		input description: "When the button is clicked a 'button 1 pushed' event is sent, but if it is held for at least 2 seconds then a 'button 1 held' event is sent when released. The settings below allow changes to the minimum time needed for a hold and the type of event sent on hold.", type: "paragraph", element: "paragraph", title: "BUTTON CONFIGURATION"
+		input description: "A button click always sends a 'button 1 pushed' event, but as a default if it is held for at least 2 seconds, a 'button 1 held' event is sent when released. The settings below allow changes to the minimum time needed for held and what type of event should be sent.", type: "paragraph", element: "paragraph", title: "BUTTON CONFIGURATION"
 		input name: "waittoHeld", type: "decimal", title: "Minimum hold time required for button held:", description: "Number of seconds (default = 2.0)", range: "0.1..120"
 		input name: "holdIsButton2", type: "bool", title: "On button hold, send 'button 2 pushed' event instead of 'button 1 held'?"
 

--- a/devicetypes/bspranger/xiaomi-button.src/xiaomi-button.groovy
+++ b/devicetypes/bspranger/xiaomi-button.src/xiaomi-button.groovy
@@ -92,14 +92,16 @@ metadata {
 		//Battery Reset Config
 		input description: "If you have installed a new battery, the toggle below will reset the Changed Battery date to help remember when it was changed.", type: "paragraph", element: "paragraph", title: "CHANGED BATTERY DATE RESET"
 		input name: "battReset", type: "bool", title: "Battery Changed?"
+		//Advanced Settings
+		input description: "Only change the settings below if you know what you're doing.", type: "paragraph", element: "paragraph", title: "ADVANCED SETTINGS"
+		//Battery Voltage Range
+		input description: "", type: "paragraph", element: "paragraph", title: "BATTERY VOLTAGE RANGE"
+		input name: "voltsmax", type: "decimal", title: "Max Volts\nA battery is at 100% at __ volts\nRange 2.8 to 3.4", range: "2.8..3.4", defaultValue: 3, required: false
+		input name: "voltsmin", type: "decimal", title: "Min Volts\nA battery is at 0% (needs replacing) at __ volts\nRange 2.0 to 2.7", range: "2..2.7", defaultValue: 2.5, required: false
 		//Live Logging Message Display Config
 		input description: "These settings affect the display of messages in the Live Logging tab of the SmartThings IDE.", type: "paragraph", element: "paragraph", title: "LIVE LOGGING"
 		input name: "infoLogging", type: "bool", title: "Display info log messages?", defaultValue: true
 		input name: "debugLogging", type: "bool", title: "Display debug log messages?"
-		//Battery Voltage Offset
-		input description: "Only change the settings below if you know what you're doing.", type: "paragraph", element: "paragraph", title: "ADVANCED SETTINGS"
-		input name: "voltsmax", type: "decimal", title: "Max Volts\nA battery is at 100% at __ volts\nRange 2.8 to 3.4", range: "2.8..3.4", defaultValue: 3, required: false
-		input name: "voltsmin", type: "decimal", title: "Min Volts\nA battery is at 0% (needs replacing) at __ volts\nRange 2.0 to 2.7", range: "2..2.7", defaultValue: 2.5, required: false
 	}
 }
 
@@ -274,7 +276,7 @@ def installed() {
 	displayInfoLog(": Installing")
 	if (!batteryRuntime)
 		resetBatteryRuntime(true)
-	checkIntervalEvent("installed")
+	checkIntervalEvent("")
 }
 
 // configure() runs after installed() when a sensor is paired
@@ -293,14 +295,15 @@ def updated() {
 		resetBatteryRuntime()
 		device.updateSetting("battReset", false)
 	}
-	checkIntervalEvent("updated")
+	checkIntervalEvent("preferences updated")
 	displayInfoLog(": Info message logging enabled")
 	displayDebugLog(": Debug message logging enabled")
 }
 
 private checkIntervalEvent(text) {
 		// Device wakes up every 1 hours, this interval allows us to miss one wakeup notification before marking offline
-		displayInfoLog(": Configured health checkInterval when ${text}")
+		if (text)
+			displayInfoLog(": Set health checkInterval when ${text}")
 		sendEvent(name: "checkInterval", value: 2 * 60 * 60 + 2 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
 }
 

--- a/devicetypes/bspranger/xiaomi-button.src/xiaomi-button.groovy
+++ b/devicetypes/bspranger/xiaomi-button.src/xiaomi-button.groovy
@@ -6,7 +6,7 @@
  *	Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  *	in compliance with the License. You may obtain a copy of the License at:
  *
- *			http://www.apache.org/licenses/LICENSE-2.0
+ *	    http://www.apache.org/licenses/LICENSE-2.0
  *
  *	Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
  *	on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
@@ -24,64 +24,64 @@
  */
 
 metadata {
-		definition (name: "Xiaomi Button", namespace: "bspranger", author: "bspranger") {
-				capability "Battery"
-				capability "Sensor"
-				capability "Button"
-				capability "Holdable Button"
-				capability "Actuator"
-				capability "Configuration"
-				capability "Health Check"
+	definition (name: "Xiaomi Button", namespace: "bspranger", author: "bspranger") {
+		capability "Battery"
+		capability "Sensor"
+		capability "Button"
+		capability "Holdable Button"
+		capability "Actuator"
+		capability "Configuration"
+		capability "Health Check"
 
-				attribute "lastCheckin", "string"
-				attribute "lastCheckinDate", "Date"
-				attribute "lastPressed", "string"
-				attribute "lastPressedDate", "string"
-				attribute "lastReleased", "string"
-				attribute "lastReleasedDate", "string"
-				attribute "lastButtonMssg", "string"
-				attribute "batteryRuntime", "string"
+		attribute "lastCheckin", "string"
+		attribute "lastCheckinCoRE", "Date"
+		attribute "lastPressed", "string"
+		attribute "lastPressedCoRE", "string"
+		attribute "lastReleased", "string"
+		attribute "lastReleasedCoRE", "string"
+		attribute "lastButtonMssg", "string"
+		attribute "batteryRuntime", "string"
 
-				fingerprint endpointId: "01", profileId: "0104", deviceId: "0104", inClusters: "0000,0003,FFFF,0019", outClusters: "0000,0004,0003,0006,0008,0005,0019", manufacturer: "LUMI", model: "lumi.sensor_switch", deviceJoinName: "Original Xiaomi Button"
+		fingerprint endpointId: "01", profileId: "0104", deviceId: "0104", inClusters: "0000,0003,FFFF,0019", outClusters: "0000,0004,0003,0006,0008,0005,0019", manufacturer: "LUMI", model: "lumi.sensor_switch", deviceJoinName: "Original Xiaomi Button"
 
-				command "resetBatteryRuntime"
-}
+		command "resetBatteryRuntime"
+	}
 
-		simulator {
-					status "Pressed": "on/off: 0"
-					status "Released": "on/off: 1"
+	simulator {
+		status "Pressed": "on/off: 0"
+		status "Released": "on/off: 1"
+	}
+
+	tiles(scale: 2) {
+		multiAttributeTile(name:"button", type: "lighting", width: 6, height: 4, canChangeIcon: true) {
+			tileAttribute ("device.button", key: "PRIMARY_CONTROL") {
+				attributeState("pushed", label:'Pushed', action: "momentary.push", backgroundColor:"#00a0dc")
+				attributeState("held", label:'Held', action: "momentary.push", backgroundColor:"#00a0dc")
+			}
+			tileAttribute("device.lastpressed", key: "SECONDARY_CONTROL") {
+				attributeState "default", label:'Last Pressed: ${currentValue}'
+			}
 		}
-
-		tiles(scale: 2) {
-			multiAttributeTile(name:"button", type: "lighting", width: 6, height: 4, canChangeIcon: true) {
-				tileAttribute ("device.button", key: "PRIMARY_CONTROL") {
-					attributeState("pushed", label:'Pushed', action: "momentary.push", backgroundColor:"#00a0dc")
-					attributeState("held", label:'Held', action: "momentary.push", backgroundColor:"#00a0dc")
-				}
-				tileAttribute("device.lastpressed", key: "SECONDARY_CONTROL") {
-					attributeState "default", label:'Last Pressed: ${currentValue}'
-				}
-			}
-			valueTile("battery", "device.battery", decoration: "flat", inactiveLabel: false, width: 2, height: 2) {
-				state "battery", label:'${currentValue}%', unit:"%", icon:"https://raw.githubusercontent.com/bspranger/Xiaomi/master/images/XiaomiBattery.png",
-				backgroundColors:[
-					[value: 10, color: "#bc2323"],
-					[value: 26, color: "#f1d801"],
-					[value: 51, color: "#44b621"]
-				]
-			}
-			valueTile("lastcheckin", "device.lastCheckin", decoration: "flat", inactiveLabel: false, width: 4, height: 1) {
-				state "default", label:'Last Event:\n${currentValue}'
-			}
-			valueTile("batteryRuntime", "device.batteryRuntime", inactiveLabel: false, decoration: "flat", width: 4, height: 1) {
-				state "batteryRuntime", label:'Battery Changed: ${currentValue}'
+		valueTile("battery", "device.battery", decoration: "flat", inactiveLabel: false, width: 2, height: 2) {
+			state "battery", label:'${currentValue}%', unit:"%", icon:"https://raw.githubusercontent.com/bspranger/Xiaomi/master/images/XiaomiBattery.png",
+			backgroundColors:[
+				[value: 10, color: "#bc2323"],
+				[value: 26, color: "#f1d801"],
+				[value: 51, color: "#44b621"]
+			]
+		}
+		valueTile("lastcheckin", "device.lastCheckin", decoration: "flat", inactiveLabel: false, width: 4, height: 1) {
+			state "default", label:'Last Event:\n${currentValue}'
+		}
+		valueTile("batteryRuntime", "device.batteryRuntime", inactiveLabel: false, decoration: "flat", width: 4, height: 1) {
+			state "batteryRuntime", label:'Battery Changed: ${currentValue}'
 		}
 		main (["button"])
 		details(["button","battery","lastcheckin","batteryRuntime"])
-	 }
-	 preferences {
+	}
+
+	preferences {
 		//Button Config
-		input name: "PressType", type: "enum", options: ["Momentary", "Toggle"], title: "Momentary or Toggle mode? ", defaultValue: "Momentary"
 		input name: "waittoHeld", type: "decimal", title: "If the button is held, wait how many seconds until sending a 'held' message?", description: "Number of seconds (default = 2.0)", range: "0.1..120"
 		//Date & Time Config
 		input description: "", type: "paragraph", element: "paragraph", title: "DATE & CLOCK"
@@ -94,19 +94,17 @@ metadata {
 		input description: "Only change the settings below if you know what you're doing.", type: "paragraph", element: "paragraph", title: "ADVANCED SETTINGS"
 		input name: "voltsmax", type: "decimal", title: "Max Volts\nA battery is at 100% at __ volts\nRange 2.8 to 3.4", range: "2.8..3.4", defaultValue: 3, required: false
 		input name: "voltsmin", type: "decimal", title: "Min Volts\nA battery is at 0% (needs replacing) at __ volts\nRange 2.0 to 2.7", range: "2..2.7", defaultValue: 2.5, required: false
-		}
+	}
 }
 
 //adds functionality to press the centre tile as a virtualApp Button
 def push() {
 	log.debug "Virtual App Button Pressed"
-	def now = formatDate()
-	def nowDate = new Date(now).getTime()
-	sendEvent(name: "lastPressed", value: now, displayed: false)
-	sendEvent(name: "lastPressedDate", value: nowDate, displayed: false)
+	sendEvent(name: "lastPressed", value: formatDate(), displayed: false)
+	sendEvent(name: "lastPressedCoRE", value: now(), displayed: false)
 	sendEvent(name: "button", value: "pushed", data: [buttonNumber: 1], descriptionText: "$device.displayName app button was pushed", isStateChange: true)
-	sendEvent(name: "lastReleased", value: now, displayed: false)
-	sendEvent(name: "lastReleasedDate", value: nowDate, displayed: false)
+	sendEvent(name: "lastReleased", value: formatDate(), displayed: false)
+	sendEvent(name: "lastReleasedCoRE", value: now(), displayed: false)
 }
 
 // Parse incoming device messages to generate events
@@ -114,13 +112,9 @@ def parse(String description) {
 	log.debug "${device.displayName}: Parsing '${description}'"
 	def result = [:]
 
-	// Determine current time and date in the user-selected date format and clock style
-	def now = formatDate()
-	def nowDate = new Date(now).getTime()
 	// Any report - button press & Battery - results in a lastCheckin event and update to Last Checkin tile
-	// However, only a non-parseable report results in lastCheckin being displayed in events log
-	sendEvent(name: "lastCheckin", value: now, displayed: false)
-	sendEvent(name: "lastCheckinDate", value: nowDate, displayed: false)
+	sendEvent(name: "lastCheckin", value: formatDate(), displayed: false)
+	sendEvent(name: "lastCheckinCoRE", value: now(), displayed: false)
 
 	// Send message data to appropriate parsing function based on the type of report
 	if (description?.startsWith('on/off: ')) {
@@ -137,34 +131,20 @@ def parse(String description) {
 private parseButtonMessage(description) {
 	def result = [:]
 	def onOff = (description - "on/off: ")
-	def nowDate = now()
-	def now = formatDate()
 
-	// in toggle mode only toggle when button is pressed
-	if (PressType == "Toggle") {
-		if (onOff == '0') {
-			if (device.currentValue('button') != "pushed")
-				result = getContactResult("pushed")
-			else
-				result = getContactResult("released")
-		}
-	}
-	// momentary mode
-	else {
-		if (onOff == '0') {
-			// on button pressed update lastPressed and lastButtonMssg to current date/time
-			log.debug "${device.displayName}: Button pressed, setting Last Pressed to current date/time"
-			sendEvent(name: "lastPressed", value: now, displayed: false)
-			sendEvent(name: "lastPressedDate", value: nowDate, displayed: false)
-			sendEvent(name: "lastButtonMssg", value: nowDate, displayed: false)
-		} else if (onOff == '1') {
-			// on button released create map for buttton pushed or held event based on held time setting
-			log.debug "${device.displayName}: Button released, setting Last Released to current date/time"
-			sendEvent(name: "lastReleased", value: now, displayed: false)
-			sendEvent(name: "lastReleasedDate", value: nowDate, displayed: false)
-			result = createButtonEvent()
-			sendEvent(name: "lastButtonMssg", value: nowDate, displayed: false)
-		}
+	if (onOff == '0') {
+		// on button pressed update lastPressed and lastButtonMssg to current date/time
+		log.debug "${device.displayName}: Button pressed, setting Last Pressed to current date/time"
+		sendEvent(name: "lastPressed", value: formatDate(), displayed: false)
+		sendEvent(name: "lastPressedCoRE", value: now(), displayed: false)
+		sendEvent(name: "lastButtonMssg", value: now(), displayed: false)
+	} else if (onOff == '1') {
+		// on button released create map for buttton pushed or held event based on held time setting
+		log.debug "${device.displayName}: Button released, setting Last Released to current date/time"
+		sendEvent(name: "lastReleased", value: formatDate(), displayed: false)
+		sendEvent(name: "lastReleasedCoRE", value: now(), displayed: false)
+		result = createButtonEvent()
+		sendEvent(name: "lastButtonMssg", value: now(), displayed: false)
 	}
 	return result
 }
@@ -174,14 +154,15 @@ private createButtonEvent() {
 	def holdTimeMillisec = Math.round((settings.waittoHeld?:2.0) * 1000)
 	def value = "held"
 
-	// compare waittoHeld setting with difference between current time and lastPressed
 	log.debug "${device.displayName}: Comparing time difference between this button release and last button message"
 	log.debug "${device.displayName}: Time difference = $timeDif ms, Hold time setting = $holdTimeMillisec"
+	// If there is an issue with message sequence do not parse this button release
 	if (timeDif < 0)
-		return [:]	// If there is an issue with message sequence do not parse this button release
-	else if (timeDif < holdTimeMillisec) 
+		return [:]
+	// compare waittoHeld setting with difference between current time and lastButtonMssg
+	else if (timeDif < holdTimeMillisec)
 		value = "pushed"
-        
+
 	return [
 		name: 'button',
 		value: value,
@@ -200,30 +181,24 @@ private Map parseReadAttrMessage(String description) {
 	def value = description.split(",").find {it.split(":")[0].trim() == "value"}?.split(":")[1].trim()
 	def model = value.split("01FF")[0]
 	def data = value.split("01FF")[1]
-	log.debug "cluster: ${cluster}, attrId: ${attrId}, value: ${value}, model:${model}, data:${data}"
 
 	if (data[4..7] == "0121") {
 		def BatteryVoltage = (Integer.parseInt((data[10..11] + data[8..9]),16))
 			resultMap = getBatteryResult(BatteryVoltage)
-			log.debug "${device.displayName}: Parse returned $resultMap"
-			createEvent(resultMap)
 	}
 
-		if (cluster == "0000" && attrId == "0005")	{
-				resultMap.name = 'Model'
-				resultMap.value = ""
-				resultMap.descriptionText = "device model"
-				// Parsing the model
-				for (int i = 0; i < model.length(); i+=2)
-				{
-						def str = model.substring(i, i+2);
-						def NextChar = (char)Integer.parseInt(str, 16);
-						resultMap.value = resultMap.value + NextChar
-				}
-				return resultMap
+	if (cluster == "0000" && attrId == "0005")	{
+		def modelName = ""
+		// Parsing the model
+		for (int i = 0; i < model.length(); i+=2) {
+			def str = model.substring(i, i+2);
+			def NextChar = (char)Integer.parseInt(str, 16);
+			modelName = modelName + NextChar
 		}
+		log.debug "${device.displayName} reported: cluster: 0000, attrId: 0005, value: ${value}, model:${modelName}, data:${data}"
+	}
 
-		return [:]
+	return resultMap
 }
 
 // Check catchall for battery voltage data to pass to getBatteryResult for conversion to percentage report
@@ -257,23 +232,20 @@ private Map getBatteryResult(rawValue) {
 	def maxVolts = voltsmax ? voltsmax : 3.0
 	def pct = (rawVolts - minVolts) / (maxVolts - minVolts)
 	def roundedPct = Math.min(100, Math.round(pct * 100))
-	def result = [
+	log.debug "${device.displayName}: ${result}"
+	return [
 		name: 'battery',
 		value: roundedPct,
 		unit: "%",
 		isStateChange:true,
 		descriptionText : "${device.displayName} Battery at ${roundedPct}% (${rawVolts} Volts)"
 	]
-
-	log.debug "${device.displayName}: ${result}"
-	return createEvent(result)
 }
 
 //Reset the date displayed in Battery Changed tile to current date
 def resetBatteryRuntime(paired) {
-	def now = formatDate(true)
 	def newlyPaired = paired ? " for newly paired sensor" : ""
-	sendEvent(name: "batteryRuntime", value: now)
+	sendEvent(name: "batteryRuntime", value: formatDate(true))
 	log.debug "${device.displayName}: Setting Battery Changed to current date${newlyPaired}"
 }
 

--- a/devicetypes/bspranger/xiaomi-button.src/xiaomi-button.groovy
+++ b/devicetypes/bspranger/xiaomi-button.src/xiaomi-button.groovy
@@ -185,14 +185,12 @@ private createButtonEvent() {
 }
 
 private Map parseReadAttrMessage(String description) {
-	def buttonRaw = (description - "read attr - raw:")
-	Map resultMap = [:]
-
 	def cluster = description.split(",").find {it.split(":")[0].trim() == "cluster"}?.split(":")[1].trim()
 	def attrId = description.split(",").find {it.split(":")[0].trim() == "attrId"}?.split(":")[1].trim()
 	def value = description.split(",").find {it.split(":")[0].trim() == "value"}?.split(":")[1].trim()
 	def model = value.split("02FF")[0]
 	def data = value.split("02FF")[1]
+	Map resultMap = [:]
 
 	if (data[4..7] == "0121") {
 		def BatteryVoltage = (Integer.parseInt((data[10..11] + data[8..9]),16))

--- a/devicetypes/bspranger/xiaomi-button.src/xiaomi-button.groovy
+++ b/devicetypes/bspranger/xiaomi-button.src/xiaomi-button.groovy
@@ -1,24 +1,24 @@
 /**
- *	Xiaomi Zigbee Button
- *	Version 1.2
+ *  Xiaomi Zigbee Button
+ *  Version 1.2
  *
  *
- *	Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- *	in compliance with the License. You may obtain a copy of the License at:
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License. You may obtain a copy of the License at:
  *
- *	    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *	Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
- *	on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
- *	for the specific language governing permissions and limitations under the License.
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ *  for the specific language governing permissions and limitations under the License.
  *
- *	Original device handler code by a4refillpad, adapted for use with Aqara model by bspranger
- *	Additional contributions to code by alecm, alixjg, bspranger, gn0st1c, foz333, jmagnuson, rinkek, ronvandegraaf, snalee, tmleafs, twonk, & veeceeoh
+ *  Original device handler code by a4refillpad, adapted for use with Aqara model by bspranger
+ *  Additional contributions to code by alecm, alixjg, bspranger, gn0st1c, foz333, jmagnuson, rinkek, ronvandegraaf, snalee, tmleafs, twonk, & veeceeoh
  *
- *	Known issues:
- *	Xiaomi sensors do not seem to respond to refresh requests
- *	Inconsistent rendering of user interface text/graphics between iOS and Android devices - This is due to SmartThings, not this device handler
- *	Pairing Xiaomi sensors can be difficult as they were not designed to use with a SmartThings hub.
+ *  Known issues:
+ *  Xiaomi sensors do not seem to respond to refresh requests
+ *  Inconsistent rendering of user interface text/graphics between iOS and Android devices - This is due to SmartThings, not this device handler
+ *  Pairing Xiaomi sensors can be difficult as they were not designed to use with a SmartThings hub.
  *
  *
  */
@@ -173,7 +173,7 @@ private createButtonEvent() {
 }
 
 private Map parseReadAttrMessage(String description) {
-	def buttonRaw = (description - "read attr - raw:")
+
 	Map resultMap = [:]
 
 	def cluster = description.split(",").find {it.split(":")[0].trim() == "cluster"}?.split(":")[1].trim()


### PR DESCRIPTION
I have reincorporated a4refillpad's method to determine whether a button "pushed" or "held" event is sent, based on the difference in time between pressing the button and releasing it.

By all reports, this method seems to be the most reliable, but still not 100% because of some press & release messages being parsed in reversed order, or even dropped by the hub. However, it's main limitation is that after pressing the button, nothing will happen until you release it. So even if the `waittoHeld` preference is set to 2 seconds, if the button is held for 10 seconds, the button "held" event only gets sent at 10 seconds, when the button is physically released.

Note that I've re-worked a4refillpad's code to remove redundancies, and to make sure the main `parse(String description)` routine is the only one calling `createEvent()`.

To try to make this DTH more versatile for WebCoRE users, I've also added `lastReleased` and `lastReleasedDate` events that are triggered when the button is physically released.

I haven't tested this DTH yet, and it really must be tested before it's released.

If this code works well enough, then I can use it to build the DTH for the new Aqara button model.