### PR TITLE
Aqara Button DTH - add support for model WXKG12LM

### DIFF
--- a/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
@@ -79,13 +79,13 @@ metadata {
 	tiles(scale: 2) {
 		multiAttributeTile(name:"buttonStatus", type: "lighting", width: 6, height: 4, canChangeIcon: false) {
 			tileAttribute ("device.buttonStatus", key: "PRIMARY_CONTROL") {
-				attributeState("default", label:'Pushed', backgroundColor:"#00a0dc", icon:"https://raw.githubusercontent.com/veeceeoh/Xiaomi/master/images/button-pushed-icn.png")
-				attributeState("pushed", label:'Pushed', backgroundColor:"#00a0dc", icon:"https://raw.githubusercontent.com/veeceeoh/Xiaomi/master/images/button-pushed-icn.png")
-				attributeState("held", label:'Held', backgroundColor:"#00a0dc", icon:"https://raw.githubusercontent.com/veeceeoh/Xiaomi/master/images/button-pushed-icn.png")
-				attributeState("single-clicked", label:'Single-clicked', backgroundColor:"#00a0dc", icon:"https://raw.githubusercontent.com/veeceeoh/Xiaomi/master/images/button-pushed-icn.png")
-				attributeState("double-clicked", label:'Double-clicked', backgroundColor:"#00a0dc", icon:"https://raw.githubusercontent.com/veeceeoh/Xiaomi/master/images/button-pushed-icn.png")
-				attributeState("shaken", label:'Shaken', backgroundColor:"#00a0dc", icon:"https://raw.githubusercontent.com/veeceeoh/Xiaomi/master/images/button-pushed-icn.png")
-				attributeState("released", label:'Released', action: "momentary.push", backgroundColor:"#ffffff", icon:"https://raw.githubusercontent.com/veeceeoh/Xiaomi/master/images/button-released-icn.png")
+				attributeState("default", label:'Pushed', backgroundColor:"#00a0dc", icon:"https://raw.githubusercontent.com/bspranger/Xiaomi/master/images/ButtonPushed.png")
+				attributeState("pushed", label:'Pushed', backgroundColor:"#00a0dc", icon:"https://raw.githubusercontent.com/bspranger/Xiaomi/master/images/ButtonPushed.png")
+				attributeState("held", label:'Held', backgroundColor:"#00a0dc", icon:"https://raw.githubusercontent.com/bspranger/Xiaomi/master/images/ButtonPushed.png")
+				attributeState("single-clicked", label:'Single-clicked', backgroundColor:"#00a0dc", icon:"https://raw.githubusercontent.com/bspranger/Xiaomi/master/images/ButtonPushed.png")
+				attributeState("double-clicked", label:'Double-clicked', backgroundColor:"#00a0dc", icon:"https://raw.githubusercontent.com/bspranger/Xiaomi/master/images/ButtonPushed.png")
+				attributeState("shaken", label:'Shaken', backgroundColor:"#00a0dc", icon:"https://raw.githubusercontent.com/bspranger/Xiaomi/master/images/ButtonPushed.png")
+				attributeState("released", label:'Released', action: "momentary.push", backgroundColor:"#ffffff", icon:"https://raw.githubusercontent.com/bspranger/Xiaomi/master/images/ButtonReleased.png")
 			}
 			tileAttribute("device.lastPressed", key: "SECONDARY_CONTROL") {
 				attributeState "lastPressed", label:'Last Pressed: ${currentValue}'

--- a/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
@@ -317,7 +317,7 @@ def updated() {
 	displayInfoLog(": Updating preference settings")
     if (!state.prefsSetCount)
 		state.prefsSetCount = 1
-	else if (state.prefsSetCount < 2)
+	else if (state.prefsSetCount < 3)
 		state.prefsSetCount = state.prefsSetCount + 1
 	if (battReset){
 		resetBatteryRuntime()

--- a/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
@@ -22,7 +22,7 @@
  *    - Only single press is supported, sent as button 1 "pushed" event
  *    - The 2-button Aqara Smart Light Switch model WXKG02LM is only recognized as ONE button.
  *      This is because the SmartThings API ignores the data that distinguishes between left, right, or both-button presses.
- *  Model WXKG11LM:
+ *  Model WXKG12LM:
  *    - Single click results in button 1 "pushed" event
  *    - Hold for longer than 400ms results in button 1 "held" event
  *    - Double click results in button 2 "pushed" event

--- a/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
@@ -56,6 +56,7 @@ metadata {
 
 		fingerprint endpointId: "01", profileId: "0104", deviceId: "5F01", inClusters: "0000,FFFF,0006", outClusters: "0000,0004,FFFF", manufacturer: "LUMI", model: "lumi.sensor_switch.aq2", deviceJoinName: "Aqara Button Model WXKG11LM"
 		fingerprint endpointId: "01", profileId: "0104", deviceId: "5F01", inClusters: "0000,0001,0006,0012", outClusters: "0000", manufacturer: "LUMI", model: "lumi.sensor_switch.aq3", deviceJoinName: "Aqara Button Model WXKG12LM"
+		fingerprint endpointId: "01", profileId: "0104", deviceId: "5F01", inClusters: "0000,0001,0006,0012", outClusters: "0000", manufacturer: "LUMI", model: "lumi.sensor_swit", deviceJoinName: "Aqara Button Model WXKG12LM"
 
 		command "resetBatteryRuntime"
 	}

--- a/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
@@ -294,20 +294,15 @@ def resetBatteryRuntime(paired) {
 def installed() {
 	state.prefsSetCount = 0
 	displayInfoLog(": Installing")
-	if (!device.currentState('batteryRuntime')?.value)
-		resetBatteryRuntime(true)
+	init(0)
 	checkIntervalEvent("")
-	sendEvent(name: "numberOfButtons", value: 3)
 }
 
 // configure() runs after installed() when a sensor is paired
 def configure() {
 	displayInfoLog(": Configuring")
-	if (!device.currentState('batteryRuntime')?.value)
-		resetBatteryRuntime(true)
+	init(1)
 	checkIntervalEvent("configured")
-	sendEvent(name: "numberOfButtons", value: 3)
-	displayInfoLog(": Number of buttons = 3")
 	return
 }
 
@@ -318,8 +313,7 @@ def updated() {
 		state.prefsSetCount = 1
 	else if (state.prefsSetCount < 3)
 		state.prefsSetCount = state.prefsSetCount + 1
-	if (!device.currentState('batteryRuntime')?.value)
-		resetBatteryRuntime(true)
+	init(0)
 	if (battReset){
 		resetBatteryRuntime()
 		device.updateSetting("battReset", false)
@@ -329,6 +323,15 @@ def updated() {
 	displayDebugLog(": Debug message logging enabled")
 }
 
+def init(displayLog) {
+	def modelName = device.getDataValue("deviceJoinName")
+	def numButtons = (modelName == "Aqara Button WXKG12LM") ? 3 : 1
+	sendEvent(name: "numberOfButtons", value: numButtons)
+	if (displayLog) {
+		displayInfoLog(": Model is $modelName")
+		displayInfoLog(": Number of buttons = $numButtons")
+	}
+}
 private checkIntervalEvent(text) {
 	// Device wakes up every 1 hours, this interval allows us to miss one wakeup notification before marking offline
 	if (text)

--- a/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
@@ -77,7 +77,7 @@ metadata {
 	}
 
 	tiles(scale: 2) {
-		multiAttributeTile(name:"buttonStatus", type: "lighting", width: 6, height: 4, canChangeIcon: true) {
+		multiAttributeTile(name:"buttonStatus", type: "lighting", width: 6, height: 4, canChangeIcon: false) {
 			tileAttribute ("device.buttonStatus", key: "PRIMARY_CONTROL") {
 				attributeState("default", label:'Pushed', backgroundColor:"#00a0dc", icon:"https://raw.githubusercontent.com/veeceeoh/Xiaomi/master/images/button-pushed-icn.png")
 				attributeState("pushed", label:'Pushed', backgroundColor:"#00a0dc", icon:"https://raw.githubusercontent.com/veeceeoh/Xiaomi/master/images/button-pushed-icn.png")

--- a/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
@@ -15,7 +15,7 @@
  *  for the specific language governing permissions and limitations under the License.
  *
  *  Original device handler code by a4refillpad, adapted for use with Aqara model by bspranger
- *  Additional contributions to code by alecm, alixjg, bspranger, gn0st1c, foz333, jmagnuson, rinkek, ronvandegraaf, snalee, tmleafs, twonk, & veeceeoh
+ *  Additional contributions to code by alecm, alixjg, bspranger, gn0st1c, foz333, jmagnuson, rinkek, ronvandegraaf, snalee, tmleafs, twonk, veeceeoh, & xtianpaiva
  *
  *  Notes on capabilities of the different models:
  *  Models WXKG11LM, WXKG01LM, WXKG02LM
@@ -55,7 +55,6 @@ metadata {
 		attribute "lastPressedCoRE", "string"
 		attribute "lastReleased", "string"
 		attribute "lastReleasedCoRE", "string"
-		attribute "lastButtonMssg", "string"
 		attribute "batteryRuntime", "string"
 
 		// Aqara Button - original revision - model WXKG11LM
@@ -167,10 +166,10 @@ private Map parseReadAttrMessage(String description) {
 	def cluster = description.split(",").find {it.split(":")[0].trim() == "cluster"}?.split(":")[1].trim()
 	def attrId = description.split(",").find {it.split(":")[0].trim() == "attrId"}?.split(":")[1].trim()
 	def value = description.split(",").find {it.split(":")[0].trim() == "value"}?.split(":")[1].trim()
-    def data = ""
-    def modelName = ""
+	def data = ""
+	def modelName = ""
 	def model = value
-    Map resultMap = [:]
+	Map resultMap = [:]
 
 	// Process model WXKG12LM button message
 	if (cluster == "0012") {
@@ -183,7 +182,7 @@ private Map parseReadAttrMessage(String description) {
 
 	// Process message on short-button press containing model name and battery voltage report
 	if (cluster == "0000" && attrId == "0005")	{
-    	if (value.length() > 45) {
+		if (value.length() > 45) {
 			model = value.split("01FF")[0]
 			data = value.split("01FF")[1]
 			if (data[4..7] == "0121") {
@@ -212,7 +211,7 @@ private mapButtonEvent(value) {
 	if (value == 4) {
 		displayInfoLog(" was released")
 		updateLastPressed("Released")
-        return [:]
+		return [:]
 	} else {
 		displayInfoLog(" was ${messageType[value]} (Button ${buttonNum[value]} ${eventType[value]})")
 		updateLastPressed("Pressed")
@@ -220,7 +219,7 @@ private mapButtonEvent(value) {
 			name: 'button',
 			value: eventType[value],
 			data: [buttonNumber: buttonNum[value]],
-			descriptionText: "$device.displayName ${messageType[value]}",
+			descriptionText: "$device.displayName was ${messageType[value]}",
 			isStateChange: true
 		]
 	}
@@ -315,10 +314,12 @@ def configure() {
 // updated() will run twice every time user presses save in preference settings page
 def updated() {
 	displayInfoLog(": Updating preference settings")
-    if (!state.prefsSetCount)
+	if (!state.prefsSetCount)
 		state.prefsSetCount = 1
 	else if (state.prefsSetCount < 3)
 		state.prefsSetCount = state.prefsSetCount + 1
+	if (!device.currentState('batteryRuntime')?.value)
+		resetBatteryRuntime(true)
 	if (battReset){
 		resetBatteryRuntime()
 		device.updateSetting("battReset", false)

--- a/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
@@ -1,206 +1,227 @@
 /**
- *  Xiaomi Aqara Zigbee Button
- *  Version 1.1
+ *  Xiaomi Aqara Button (models WXKG11LM and WXKG12LM)
+ *  Version 1.2
+ *
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  *  in compliance with the License. You may obtain a copy of the License at:
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *	    http://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
  *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
  *  for the specific language governing permissions and limitations under the License.
  *
  *  Original device handler code by a4refillpad, adapted for use with Aqara model by bspranger
- *  Additional contributions to code by alecm, alixjg, bspranger, gn0st1c, foz333, jmagnuson, rinkek, ronvandegraaf, snalee, tmleafs, twonk, & veeceeoh 
- * 
+ *  Additional contributions to code by alecm, alixjg, bspranger, gn0st1c, foz333, jmagnuson, rinkek, ronvandegraaf, snalee, tmleafs, twonk, & veeceeoh
+ *
+ *  Notes on capabilities of the two Aqara models:
+ *  Model WXKG11LM
+ *    - Only single press is supported, sent as button 1 "pushed" event
+ *  Model WXKG11LM:
+ *    - Single click results in button 1 "pushed" event
+ *    - Hold for longer than 400ms results in button 1 "held" event
+ *    - Double click results in button 2 "pushed" event
+ *    - Shaking the button results in button 3 "pushed" event
+ *    - Single or double click results in custom "lastPressedCoRE" event for webCoRE use
+ *    - Release of button results in "lastReleasedCoRE" event for webCoRE use
+ *
  *  Known issues:
  *  Xiaomi sensors do not seem to respond to refresh requests
  *  Inconsistent rendering of user interface text/graphics between iOS and Android devices - This is due to SmartThings, not this device handler
  *  Pairing Xiaomi sensors can be difficult as they were not designed to use with a SmartThings hub.
  *
- *  Fingerprint Endpoint data:
- *  zbjoin: {"dni":"xxxx","d":"xxxxxxxxxxx","capabilities":"80","endpoints":[{"simple":"01 0104 5F01 01 03 0000 FFFF 0006 03 0000 0004 FFFF","application":"03","manufacturer":"LUMI","model":"lumi.sensor_switch.aq2"}],"parent":"0000","joinType":1}
- *     endpoints data
- *        01 - endpoint id
- *        0104 - profile id
- *        5F01 - device id
- *        01 - ignored
- *        03 - number of in clusters
- *        0000 ffff 0006 - inClusters
- *        03 - number of out clusters
- *        0000 0004 ffff - outClusters
- *        manufacturer "LUMI" - must match manufacturer field in fingerprint
- *        model "lumi.sensor_switch.aq2" - must match model in fingerprint
- *        deviceJoinName: whatever you want it to show in the app as a Thing
  *
  */
+
 metadata {
-    definition (name: "Xiaomi Aqara Button", namespace: "bspranger", author: "bspranger") {
-        capability "Configuration"
-        capability "Sensor"
-        capability "Button"
-        capability "Holdable Button"
-        capability "Actuator"
-        capability "Switch"
-        capability "Momentary"
-        capability "Battery"
-        capability "Health Check"
+	definition (name: "Xiaomi Button", namespace: "bspranger", author: "bspranger") {
+		capability "Battery"
+		capability "Sensor"
+		capability "Button"
+		capability "Holdable Button"
+		capability "Actuator"
+		capability "Momentary"
+		capability "Configuration"
+		capability "Health Check"
 
-        attribute "lastCheckin", "string"
-        attribute "lastCheckinDate", "Date"
-	attribute "lastpressed", "string"
-        attribute "lastpressedDate", "string"
-        attribute "batteryRuntime", "String"
+		attribute "lastCheckin", "string"
+		attribute "lastCheckinCoRE", "Date"
+		attribute "lastPressed", "string"
+		attribute "lastPressedCoRE", "string"
+		attribute "lastReleased", "string"
+		attribute "lastReleasedCoRE", "string"
+		attribute "lastButtonMssg", "string"
+		attribute "batteryRuntime", "string"
 
-        command "resetBatteryRuntime"
+		fingerprint endpointId: "01", profileId: "0104", deviceId: "5F01", inClusters: "0000,FFFF,0006", outClusters: "0000,0004,FFFF", manufacturer: "LUMI", model: "lumi.sensor_switch.aq2", deviceJoinName: "Aqara Button Model WXKG11LM"
+		fingerprint endpointId: "01", profileId: "0104", deviceId: "5F01", inClusters: "0000,FFFF,0006", outClusters: "0000,0004,0012,FFFF", manufacturer: "LUMI", model: "lumi.sensor_switch.aq3", deviceJoinName: "Aqara Button Model WXKG12LM"
 
-        fingerprint endpointId: "01", profileId: "0104", deviceId: "5F01", inClusters: "0000,FFFF,0006", outClusters: "0000,0004,FFFF", manufacturer: "LUMI", model: "lumi.sensor_switch.aq2", deviceJoinName: "Xiaomi Aqara Button"
-    }
+		command "resetBatteryRuntime"
+	}
 
-    simulator {
-        status "button 1 pressed": "on/off: 0"
-        status "button 1 released": "on/off: 1"
-    }
+	simulator {
+		status "Press button": "on/off: 0"
+		status "Release button": "on/off: 1"
+	}
 
-    tiles(scale: 2) {
-        multiAttributeTile(name:"button", type:"lighting", width: 6, height: 4, canChangeIcon: true) {
-            tileAttribute("device.button", key: "PRIMARY_CONTROL") {
-                attributeState "pushed", label:'Push', action: "momentary.push", backgroundColor:"#00a0dc"
-                attributeState "released", label:'Push', action: "momentary.push", backgroundColor:"#ffffff", nextState: "pushed"
-            }
-            tileAttribute("device.lastpressed", key: "SECONDARY_CONTROL") {
-                attributeState "default", label:'Last Pressed: ${currentValue}'
-            }
-        }
-        valueTile("battery", "device.battery", decoration: "flat", inactiveLabel: false, width: 2, height: 2) {
-            state "battery", label:'${currentValue}%', unit:"%", icon:"https://raw.githubusercontent.com/bspranger/Xiaomi/master/images/XiaomiBattery.png",
-            backgroundColors:[
-                [value: 10, color: "#bc2323"],
-                [value: 26, color: "#f1d801"],
-                [value: 51, color: "#44b621"]
-            ]
-        }
-        valueTile("lastcheckin", "device.lastCheckin", decoration:"flat", inactiveLabel: false, width: 4, height: 1) {
-            state "default", label:'Last Event:\n${currentValue}'
-        }
-        valueTile("batteryRuntime", "device.batteryRuntime", decoration:"flat", inactiveLabel: false, width: 4, height: 1) {
-            state "batteryRuntime", label:'Battery Changed:\n ${currentValue}'
-        }
+	tiles(scale: 2) {
+		multiAttributeTile(name:"button", type: "lighting", width: 6, height: 4, canChangeIcon: true) {
+			tileAttribute ("device.button", key: "PRIMARY_CONTROL") {
+				attributeState("pushed", label:'Pushed', action: "momentary.push", backgroundColor:"#00a0dc")
+				attributeState("held", label:'Held', backgroundColor:"#00a0dc")
+			}
+			tileAttribute("device.lastpressed", key: "SECONDARY_CONTROL") {
+				attributeState "default", label:'Last Pressed: ${currentValue}'
+			}
+		}
+		valueTile("battery", "device.battery", decoration: "flat", inactiveLabel: false, width: 2, height: 2) {
+			state "battery", label:'${currentValue}%', unit:"%", icon:"https://raw.githubusercontent.com/bspranger/Xiaomi/master/images/XiaomiBattery.png",
+			backgroundColors:[
+				[value: 10, color: "#bc2323"],
+				[value: 26, color: "#f1d801"],
+				[value: 51, color: "#44b621"]
+			]
+		}
+		valueTile("lastcheckin", "device.lastCheckin", decoration: "flat", inactiveLabel: false, width: 4, height: 1) {
+			state "default", label:'Last Event:\n${currentValue}'
+		}
+		valueTile("batteryRuntime", "device.batteryRuntime", inactiveLabel: false, decoration: "flat", width: 4, height: 1) {
+			state "batteryRuntime", label:'Battery Changed: ${currentValue}'
+		}
+		main (["button"])
+		details(["button","battery","lastcheckin","batteryRuntime"])
+	}
 
-        main (["button"])
-        details(["button","battery","lastcheckin","batteryRuntime"])
-   }
-   preferences {
-		//Button Config
-		input name:"ReleaseTime", type:"number", title:"Minimum time in seconds for a press to clear", defaultValue: 2
-        	input name: "PressType", type: "enum", options: ["Momentary", "Toggle"], title: "Momentary or toggle? ", defaultValue: "Momentary"
+	preferences {
 		//Date & Time Config
-		input description: "", type: "paragraph", element: "paragraph", title: "DATE & CLOCK"    
+		input description: "", type: "paragraph", element: "paragraph", title: "DATE & CLOCK"
 		input name: "dateformat", type: "enum", title: "Set Date Format\n US (MDY) - UK (DMY) - Other (YMD)", description: "Date Format", options:["US","UK","Other"]
 		input name: "clockformat", type: "bool", title: "Use 24 hour clock?"
 		//Battery Reset Config
-            	input description: "If you have installed a new battery, the toggle below will reset the Changed Battery date to help remember when it was changed.", type: "paragraph", element: "paragraph", title: "CHANGED BATTERY DATE RESET"
+		input description: "If you have installed a new battery, the toggle below will reset the Changed Battery date to help remember when it was changed.", type: "paragraph", element: "paragraph", title: "CHANGED BATTERY DATE RESET"
 		input name: "battReset", type: "bool", title: "Battery Changed?"
-		//Battery Voltage Offset
-            	input description: "Only change the settings below if you know what you're doing.", type: "paragraph", element: "paragraph", title: "ADVANCED SETTINGS"
-		input name: "voltsmax", title: "Max Volts\nA battery is at 100% at __ volts\nRange 2.8 to 3.4", type: "decimal", range: "2.8..3.4", defaultValue: 3, required: false
-		input name: "voltsmin", title: "Min Volts\nA battery is at 0% (needs replacing) at __ volts\nRange 2.0 to 2.7", type: "decimal", range: "2..2.7", defaultValue: 2.5, required: false
-     }
+		//Advanced Settings
+		input description: "Only change the settings below if you know what you're doing.", type: "paragraph", element: "paragraph", title: "ADVANCED SETTINGS"
+		//Battery Voltage Range
+		input description: "", type: "paragraph", element: "paragraph", title: "BATTERY VOLTAGE RANGE"
+		input name: "voltsmax", type: "decimal", title: "Max Volts\nA battery is at 100% at __ volts\nRange 2.8 to 3.4", range: "2.8..3.4", defaultValue: 3, required: false
+		input name: "voltsmin", type: "decimal", title: "Min Volts\nA battery is at 0% (needs replacing) at __ volts\nRange 2.0 to 2.7", range: "2..2.7", defaultValue: 2.5, required: false
+		//Live Logging Message Display Config
+		input description: "These settings affect the display of messages in the Live Logging tab of the SmartThings IDE.", type: "paragraph", element: "paragraph", title: "LIVE LOGGING"
+		input name: "infoLogging", type: "bool", title: "Display info log messages?", defaultValue: true
+		input name: "debugLogging", type: "bool", title: "Display debug log messages?"
+	}
 }
 
 //adds functionality to press the centre tile as a virtualApp Button
 def push() {
-	log.debug "Virtual App Button Pressed"
-	def now = formatDate()
-	def nowDate = new Date(now).getTime()
-	sendEvent(name: "lastpressed", value: now, displayed: false)
-        sendEvent(name: "lastpressedDate", value: nowDate, displayed: false) 
+	displayInfoLog(": Virtual App Button Pressed")
+	sendEvent(name: "lastPressed", value: formatDate(), displayed: false)
+	sendEvent(name: "lastPressedCoRE", value: now(), displayed: false)
 	sendEvent(name: "button", value: "pushed", data: [buttonNumber: 1], descriptionText: "$device.displayName app button was pushed", isStateChange: true)
-	sendEvent(name: "button", value: "released", data: [buttonNumber: 1], descriptionText: "$device.displayName app button was released", isStateChange: true)
+	sendEvent(name: "lastReleased", value: formatDate(), displayed: false)
+	sendEvent(name: "lastReleasedCoRE", value: now(), displayed: false)
 }
 
 // Parse incoming device messages to generate events
 def parse(String description) {
-    def result = zigbee.getEvent(description)
+	displayDebugLog(": Parsing '${description}'")
+	def result = [:]
 
-    if(result) {
-        log.debug "${device.displayName}: Parsing '${description}' Event Result: ${result}"
-    }
-    else
-    {
-        log.debug "${device.displayName}: Parsing '${description}'"
-    }
-	// Determine current time and date in the user-selected date format and clock style
-    def now = formatDate()    
-    def nowDate = new Date(now).getTime()
 	// Any report - button press & Battery - results in a lastCheckin event and update to Last Checkin tile
-	// However, only a non-parseable report results in lastCheckin being displayed in events log
-    sendEvent(name: "lastCheckin", value: now, displayed: false)
-    sendEvent(name: "lastCheckinDate", value: nowDate, displayed: false)
-
-    Map map = [:]
+	sendEvent(name: "lastCheckin", value: formatDate(), displayed: false)
+	sendEvent(name: "lastCheckinCoRE", value: now(), displayed: false)
 
 	// Send message data to appropriate parsing function based on the type of report
-    if (description?.startsWith('on/off: '))
-    {
-        map = parseCustomMessage(description)
-        sendEvent(name: "lastpressed", value: now, displayed: false)
-        sendEvent(name: "lastpressedDate", value: nowDate, displayed: false)
-    }
-    else if (description?.startsWith('catchall:'))
-    {
-        map = parseCatchAllMessage(description)
-    }
-    else if (description?.startsWith("read attr - raw: "))
-    {
-        map = parseReadAttrMessage(description)
-    }
-    log.debug "${device.displayName}: Parse returned $map"
-    def results = map ? createEvent(map) : null
-
-    return results;
+	if (description?.startsWith('on/off: ')) {
+		// Model WXKG11LM only - button press generates pushed event
+		updateLastPressed("pressed")
+		result = buttonEventMap(0)
+	} else if (description?.startsWith("read attr - raw: ")) {
+		// Parse any model WXKG12LM button messages, or messages on short-press of reset button
+		result = parseReadAttrMessage(description)
+	} else if (description?.startsWith('catchall:')) {
+		// Parse battery level from regular hourly announcement messages
+		result = parseCatchAllMessage(description)
+	}
+	if (result != [:]) {
+		displayDebugLog(": Creating event $result")
+		return createEvent(result)
+	} else
+		return [:]
 }
 
 private Map parseReadAttrMessage(String description) {
-    def buttonRaw = (description - "read attr - raw:")
-    Map resultMap = [:]
+	def cluster = description.split(",").find {it.split(":")[0].trim() == "cluster"}?.split(":")[1].trim()
+	def attrId = description.split(",").find {it.split(":")[0].trim() == "attrId"}?.split(":")[1].trim()
+	def value = description.split(",").find {it.split(":")[0].trim() == "value"}?.split(":")[1].trim()
+	Map resultMap = [:]
+	displayDebugLog(" parsed message: cluster: $cluster, attrId: $attrId, value: $value")
 
-    def cluster = description.split(",").find {it.split(":")[0].trim() == "cluster"}?.split(":")[1].trim()
-    def attrId = description.split(",").find {it.split(":")[0].trim() == "attrId"}?.split(":")[1].trim()
-    def value = description.split(",").find {it.split(":")[0].trim() == "value"}?.split(":")[1].trim()
-    def model = value.split("01FF")[0]
-    def data = value.split("01FF")[1]
-    //log.debug "cluster: ${cluster}, attrId: ${attrId}, value: ${value}, model:${model}, data:${data}"
+	// Process model WXKG12LM button message
+	if (cluster == "0012") {
+		// Values (as integer): 1 = push, 2 = double-click, 16 = hold, 17 = release, 18 = shake
+		value = Integer.parseInt(value[2..3])
+		// Change values 16-18 to 3-5 to use as list for buttonEventMap function
+		value = (value < 3)?:(value - 13)
+		result = mapButtonEvent(value)
+	}
 
-    if (data[4..7] == "0121") {
-        def BatteryVoltage = (Integer.parseInt((data[10..11] + data[8..9]),16))
-        resultMap = getBatteryResult(BatteryVoltage)
-        log.debug "${device.displayName}: Parse returned $resultMap"
-        createEvent(resultMap)
-    }
+	// Process message on short-button press containing model name and battery voltage report
+	if (cluster == "0000" && attrId == "0005")	{
+		def model = value.split("01FF")[0]
+		def data = value.split("01FF")[1]
+		def modelName = ""
+		// Parsing the model name
+		for (int i = 0; i < model.length(); i+=2) {
+			def str = model.substring(i, i+2);
+			def NextChar = (char)Integer.parseInt(str, 16);
+			modelName = modelName + NextChar
+		}
+		displayDebugLog(" reported: cluster: 0000, attrId: 0005, value: ${value}, model:${modelName}, data:${data}")
 
-    if (cluster == "0000" && attrId == "0005") {
-        resultMap.name = 'Model'
-        resultMap.value = ""
-        resultMap.descriptionText = "device model"
-        // Parsing the model
-        for (int i = 0; i < model.length(); i+=2)
-        {
-            def str = model.substring(i, i+2);
-            def NextChar = (char)Integer.parseInt(str, 16);
-            resultMap.value = resultMap.value + NextChar
-        }
-        return resultMap
-    }
-    return [:]
+		if (data[4..7] == "0121") {
+			def BatteryVoltage = (Integer.parseInt((data[10..11] + data[8..9]),16))
+				resultMap = getBatteryResult(BatteryVoltage)
+		}
+	}
+
+	return resultMap
+}
+
+// Create map of values to be used for button event
+private mapButtonEvent(value) {
+	def messageType = ["pushed", "clicked", "double-clicked", "held", "", "shaken"]
+	def eventType = ["pushed", "pushed", "pushed", "held", "", "shaken"]
+	def buttonNum = [1, 1, 2, 1, 0, 3]
+	if (value == 4) {
+		displayInfoLog(" was released")
+		updateLastPressed("Released")
+	} else {
+		displayInfoLog(" was $messageType[value] (Button $buttonNum[value] $eventType[value])")
+		updateLastPressed("Pressed")
+		return [
+			name: 'button',
+			value: value,
+			data: [buttonNumber: buttonNum[value]],
+			descriptionText: "$device.displayName was $value",
+			isStateChange: true
+		]
+	}
+}
+
+// on any type of button pressed update lastPressed or lastReleased to current date/time
+def updateLastPressed(pressType) {
+	displayInfoLog(": Setting Last $pressType to current date/time")
+	sendEvent(name: "last{$pressType}", value: formatDate(), displayed: false)
+	sendEvent(name: "last{$pressType}CoRE", value: now(), displayed: false)
 }
 
 // Check catchall for battery voltage data to pass to getBatteryResult for conversion to percentage report
 private Map parseCatchAllMessage(String description) {
 	Map resultMap = [:]
 	def catchall = zigbee.parse(description)
-	log.debug catchall
 
 	if (catchall.clusterId == 0x0000) {
 		def MsgLength = catchall.data.size()
@@ -220,157 +241,109 @@ private Map parseCatchAllMessage(String description) {
 
 // Convert raw 4 digit integer voltage value into percentage based on minVolts/maxVolts range
 private Map getBatteryResult(rawValue) {
-    // raw voltage is normally supplied as a 4 digit integer that needs to be divided by 1000
-    // but in the case the final zero is dropped then divide by 100 to get actual voltage value 
-    def rawVolts = rawValue / 1000
-    def minVolts
-    def maxVolts
-
-    if(voltsmin == null || voltsmin == "")
-    	minVolts = 2.5
-    else
-   	minVolts = voltsmin
-    
-    if(voltsmax == null || voltsmax == "")
-    	maxVolts = 3.0
-    else
-	maxVolts = voltsmax    
- 
-    def pct = (rawVolts - minVolts) / (maxVolts - minVolts)
-    def roundedPct = Math.min(100, Math.round(pct * 100))
-
-    def result = [
-        name: 'battery',
-        value: roundedPct,
-        unit: "%",
-        isStateChange:true,
-	    descriptionText : "${device.displayName} Battery at ${roundedPct}% (${rawVolts} Volts)"
-    ]
-
-    log.debug "${device.displayName}: ${result}"
-    return createEvent(result)
+	// raw voltage is normally supplied as a 4 digit integer that needs to be divided by 1000
+	// but in the case the final zero is dropped then divide by 100 to get actual voltage value
+	def rawVolts = rawValue / 1000
+	def minVolts = voltsmin ? voltsmin : 2.5
+	def maxVolts = voltsmax ? voltsmax : 3.0
+	def pct = (rawVolts - minVolts) / (maxVolts - minVolts)
+	def roundedPct = Math.min(100, Math.round(pct * 100))
+	def descText = "Battery at ${roundedPct}% (${rawVolts} Volts)"
+	displayInfoLog(": $descText")
+	return [
+		name: 'battery',
+		value: roundedPct,
+		unit: "%",
+		isStateChange:true,
+		descriptionText : "$device.displayName $descText"
+	]
 }
 
-private Map parseCustomMessage(String description) {
-    def result = [:]
-    if (description?.startsWith('on/off: '))
-    {
-        if (PressType == "Toggle")
-        {
-            if ((state.button != "pushed") && (state.button != "released"))
-            {
-                state.button = "released"
-            }
-            if (state.button == "released")
-            {
-                result = getContactResult("pushed")
-                state.button = "pushed"
-            }
-            else
-            {
-                result = getContactResult("released")
-                state.button = "released"
-            }
-        }
-        else
-        {
-            result = getContactResult("pushed")
-            state.button = "pushed"
-            runIn(ReleaseTime, ReleaseButton)
-        }
-    }
-     return result
+private def displayDebugLog(message) {
+	if (debugLogging)
+		log.debug "${device.displayName}${message}"
 }
 
-def ReleaseButton()
-{
-    def result = [:]
-    log.debug "${device.displayName}: Calling Release Button"
-    result = getContactResult("released")
-    state.button = "released"
-    log.debug "${device.displayName}: ${result}"
-    sendEvent(result)
-}
-
-private Map getContactResult(value) {
-    def descriptionText = "${device.displayName} was ${value == 'pushed' ? 'pushed' : 'released'}"
-    return [
-        name: 'button',
-        value: value,
-        data: [buttonNumber: "1"],
-        isStateChange: true,
-        descriptionText: descriptionText
-    ]
+private def displayInfoLog(message) {
+	if (infoLogging)
+		log.info "${device.displayName}${message}"
 }
 
 //Reset the date displayed in Battery Changed tile to current date
 def resetBatteryRuntime(paired) {
-	def now = formatDate(true)
 	def newlyPaired = paired ? " for newly paired sensor" : ""
-	sendEvent(name: "batteryRuntime", value: now)
-	log.debug "${device.displayName}: Setting Battery Changed to current date${newlyPaired}"
+	sendEvent(name: "batteryRuntime", value: formatDate(true))
+	displayInfoLog(": Setting Battery Changed to current date${newlyPaired}")
 }
 
 // installed() runs just after a sensor is paired using the "Add a Thing" method in the SmartThings mobile app
 def installed() {
-	state.battery = 0
-	if (!batteryRuntime) resetBatteryRuntime(true)
-	checkIntervalEvent("installed")
+	displayInfoLog(": Installing")
+	if (!batteryRuntime)
+		resetBatteryRuntime(true)
+	checkIntervalEvent("")
+	sendEvent(name: "numberOfButtons", value: 3)
 }
 
 // configure() runs after installed() when a sensor is paired
 def configure() {
-	log.debug "${device.displayName}: configuring"
-		state.battery = 0
-	if (!batteryRuntime) resetBatteryRuntime(true)
+	displayInfoLog(": Configuring")
+	if (!batteryRuntime)
+		resetBatteryRuntime(true)
 	checkIntervalEvent("configured")
+	sendEvent(name: "numberOfButtons", value: 3)
+	displayInfoLog(": Number of buttons = 3")
 	return
 }
 
 // updated() will run twice every time user presses save in preference settings page
 def updated() {
-		checkIntervalEvent("updated")
-		if(battReset){
+	displayInfoLog(": Updating preference settings")
+	if (battReset){
 		resetBatteryRuntime()
 		device.updateSetting("battReset", false)
 	}
+	checkIntervalEvent("preferences updated")
+	displayInfoLog(": Info message logging enabled")
+	displayDebugLog(": Debug message logging enabled")
 }
 
 private checkIntervalEvent(text) {
-    // Device wakes up every 1 hours, this interval allows us to miss one wakeup notification before marking offline
-    log.debug "${device.displayName}: Configured health checkInterval when ${text}()"
-    sendEvent(name: "checkInterval", value: 2 * 60 * 60 + 2 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
+	// Device wakes up every 1 hours, this interval allows us to miss one wakeup notification before marking offline
+	if (text)
+		displayInfoLog(": Set health checkInterval when ${text}")
+	sendEvent(name: "checkInterval", value: 2 * 60 * 60 + 2 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
 }
 
 def formatDate(batteryReset) {
-    def correctedTimezone = ""
-    def timeString = clockformat ? "HH:mm:ss" : "h:mm:ss aa"
+	def correctedTimezone = ""
+	def timeString = clockformat ? "HH:mm:ss" : "h:mm:ss aa"
 
 	// If user's hub timezone is not set, display error messages in log and events log, and set timezone to GMT to avoid errors
-    if (!(location.timeZone)) {
-        correctedTimezone = TimeZone.getTimeZone("GMT")
-        log.error "${device.displayName}: Time Zone not set, so GMT was used. Please set up your location in the SmartThings mobile app."
-        sendEvent(name: "error", value: "", descriptionText: "ERROR: Time Zone not set, so GMT was used. Please set up your location in the SmartThings mobile app.")
-    } 
-    else {
-        correctedTimezone = location.timeZone
-    }
-    if (dateformat == "US" || dateformat == "" || dateformat == null) {
-        if (batteryReset)
-            return new Date().format("MMM dd yyyy", correctedTimezone)
-        else
-            return new Date().format("EEE MMM dd yyyy ${timeString}", correctedTimezone)
-    }
-    else if (dateformat == "UK") {
-        if (batteryReset)
-            return new Date().format("dd MMM yyyy", correctedTimezone)
-        else
-            return new Date().format("EEE dd MMM yyyy ${timeString}", correctedTimezone)
-        }
-    else {
-        if (batteryReset)
-            return new Date().format("yyyy MMM dd", correctedTimezone)
-        else
-            return new Date().format("EEE yyyy MMM dd ${timeString}", correctedTimezone)
-    }
+	if (!(location.timeZone)) {
+		correctedTimezone = TimeZone.getTimeZone("GMT")
+		log.error "${device.displayName}: Time Zone not set, so GMT was used. Please set up your location in the SmartThings mobile app."
+		sendEvent(name: "error", value: "", descriptionText: "ERROR: Time Zone not set, so GMT was used. Please set up your location in the SmartThings mobile app.")
+	}
+	else {
+		correctedTimezone = location.timeZone
+	}
+	if (dateformat == "US" || dateformat == "" || dateformat == null) {
+		if (batteryReset)
+			return new Date().format("MMM dd yyyy", correctedTimezone)
+		else
+			return new Date().format("EEE MMM dd yyyy ${timeString}", correctedTimezone)
+	}
+	else if (dateformat == "UK") {
+		if (batteryReset)
+			return new Date().format("dd MMM yyyy", correctedTimezone)
+		else
+			return new Date().format("EEE dd MMM yyyy ${timeString}", correctedTimezone)
+	}
+	else {
+		if (batteryReset)
+			return new Date().format("yyyy MMM dd", correctedTimezone)
+		else
+			return new Date().format("EEE yyyy MMM dd ${timeString}", correctedTimezone)
+	}
 }

--- a/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
@@ -280,7 +280,7 @@ private def displayDebugLog(message) {
 }
 
 private def displayInfoLog(message) {
-	if (infoLogging || state.prefsSetCount < 2)
+	if (infoLogging || state.prefsSetCount < 3)
 		log.info "${device.displayName}${message}"
 }
 


### PR DESCRIPTION
Aqara Button DTH code reworked to add support for the new Aqara Button model WXKG12LM.

Supports all four button event messages, click, double-click, hold, and shake, emulating a 3-button device as follows:

Button action | Event sent to hub
-----|-----
single-click | `button 1 pushed`
hold | `button 1 held`
double-click | `button 2 pushed`
shake | `button 3 pushed`

On any of the above button events, `lastPressed` and `lastPressedCoRE` events with a date/time stamp are also sent, the former for main tile display, and the latter being useful for webCoRE users.

Note that although the button sends a message on release after being held, SmartThings no longer supports a `button released` event, so only custom `lastReleased` and `lastReleasedCoRE` events are generated, to be used by webCoRE users or people using custom Smart Apps that can access non-standard attribute events.

Other changes:
• removed `button released` event from previous DTH code
• added Advanced Settings section in preference page
• added info log and debug log message display toggle settings to Advanced Settings section, with default of info log display turned on and debug log display off
• grouped log messages into info and debug categories and changed to use new log message display calls `displayDebugLog()` and `displayInfoLog()`
• edited some log message text for clarity
• removed redundant and non-useful log messages
• added some new log messages related to the code added for the new Aqara model 
• changed `lastCheckinDate` event attribute to `lastCheckinCoRE`
• switched to use more accurate _Epoch Time Stamp_ method of now() for all ____CoRE events
• switched method for human readable date stamp of events to directly call `formatDate()` routine in the DTH