### PR TITLE
Change Xiaomi Motion Sensor "No Motion" from 60s to 6s

### DIFF
--- a/devicetypes/bspranger/xiaomi-motion-sensor.src/xiaomi-motion-sensor.groovy
+++ b/devicetypes/bspranger/xiaomi-motion-sensor.src/xiaomi-motion-sensor.groovy
@@ -84,8 +84,8 @@ metadata {
 
    preferences {
 		//Reset to No Motion Config
-		input description: "This setting only changes how long MOTION DETECTED is reported in SmartThings. The sensor hardware always remains blind to motion for 60 seconds after any activity.", type: "paragraph", element: "paragraph", title: "MOTION RESET"
-		input "motionreset", "number", title: "", description: "Enter number of seconds (default = 60)", range: "1..7200"
+		input description: "This setting only changes how long MOTION DETECTED is reported in SmartThings. The sensor hardware always remains blind to motion for 6 seconds after any activity.", type: "paragraph", element: "paragraph", title: "MOTION RESET"
+		input "motionreset", "number", title: "", description: "Enter number of seconds (default = 6)", range: "1..7200"
 		//Date & Time Config
 		input description: "", type: "paragraph", element: "paragraph", title: "DATE & CLOCK"    
 		input name: "dateformat", type: "enum", title: "Set Date Format\n US (MDY) - UK (DMY) - Other (YMD)", description: "Date Format", options:["US","UK","Other"]
@@ -141,7 +141,7 @@ private Map parseReportAttributeMessage(String description) {
 	// The sensor only sends a motion detected message so the reset to no motion is performed in code
 	if (cluster == "0406" & value == "01") {
 		log.debug "${device.displayName} detected motion"
-		def seconds = motionreset ? motionreset : 60
+		def seconds = motionreset ? motionreset : 6
 		resultMap = [
 			name: 'motion',
 			value: 'active',
@@ -220,7 +220,7 @@ private Map getBatteryResult(rawValue) {
 // If currently in 'active' motion detected state, stopMotion() resets to 'inactive' state and displays 'no motion'
 def stopMotion() {
 	if (device.currentState('motion')?.value == "active") {
-		def seconds = motionreset ? motionreset : 60
+		def seconds = motionreset ? motionreset : 6
 		sendEvent(name:"motion", value:"inactive", isStateChange: true)
 		log.debug "${device.displayName} reset to no motion after ${seconds} seconds"
 	}


### PR DESCRIPTION
Not sure if there is a newer version of Xiaomi Motion Sensors or what...
Tested on 5 Xiaomi Motion Sensors: the motion detection is re-enabled in ~5-6 seconds.